### PR TITLE
ci: use GHA matrix to build two images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,16 @@ on:
 jobs:
   build-main:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - dockerfile: ./Dockerfile
+          image: starbops/kubebmc-controller
+        - dockerfile: ./Dockerfile.kbmc
+          image: starbops/kbmc
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.22'
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -28,30 +31,14 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: |
-            starbops/kubebmc-controller
-            starbops/kbmc
-    - name: Test
-      run: make test
-    - name: Build
-      run: make build
-    - name: Docker build and push (controller)
+        images: ${{ matrix.image }}
+    - name: Docker build and push
       uses: docker/build-push-action@v6
       with:
         provenance: false
         context: .
         platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-    - name: Docker build and push (kbmc)
-      uses: docker/build-push-action@v6
-      with:
-        provenance: false
-        context: .
-        platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile.kbmc
+        file: ${{ matrix.dockerfile }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,6 +9,13 @@ on:
 jobs:
   build-pr:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - dockerfile: ./Dockerfile
+          image: starbops/kubebmc-controller
+        - dockerfile: ./Dockerfile.kbmc
+          image: starbops/kbmc
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
@@ -24,30 +31,18 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: |
-            starbops/kubebmc-controller
-            starbops/kbmc
-    - name: Test
+        images: ${{ matrix.image }}
+    - name: Run tests
       run: make test
-    - name: Build
+    - name: Build binaries
       run: make build
-    - name: Docker build (controller)
+    - name: Docker build
       uses: docker/build-push-action@v6
       with:
         provenance: false
         context: .
         platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile
-        push: false
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-    - name: Docker build (kbmc)
-      uses: docker/build-push-action@v6
-      with:
-        provenance: false
-        context: .
-        platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile.kbmc
+        file: ${{ matrix.dockerfile }}
         push: false
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,13 +8,16 @@ on:
 jobs:
   build-tag:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - dockerfile: ./Dockerfile
+          image: starbops/kubebmc-controller
+        - dockerfile: ./Dockerfile.kbmc
+          image: starbops/kbmc
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.22'
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -28,30 +31,14 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: |
-          starbops/kubebmc-controller
-          starbops/kbmc
-    - name: Test
-      run: make test
-    - name: Build
-      run: make build
-    - name: Docker build and push (controller)
+        images: ${{ matrix.image }}
+    - name: Docker build and push
       uses: docker/build-push-action@v6
       with:
         provenance: false
         context: .
         platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-    - name: Docker build and push (kbmc)
-      uses: docker/build-push-action@v6
-      with:
-        provenance: false
-        context: .
-        platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile.kbmc
+        file: ${{ matrix.dockerfile }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
According to docker/build-push-action#561, we can leverage GHA `matrix` to solve the issue.

Related issue: #14 