### PR TITLE
fix(agent): change ipmi bind port to 10623

### DIFF
--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -6,7 +6,7 @@ const (
 	virtBMCContainerName       = "virtbmc"
 	virtBMCImageName           = "starbops/virtbmc"
 	virtBMCImageTag            = "dev"
-	ipmiPort                   = 623
+	ipmiPort                   = 10623
 	IPMISvcPort                = 623
 	ipmiPortName               = "ipmi"
 	VirtualMachineBMCNameLabel = "kubevirt.io/virtualmachinebmc-name"

--- a/internal/controller/virtualmachinebmc/controller.go
+++ b/internal/controller/virtualmachinebmc/controller.go
@@ -19,6 +19,7 @@ package virtualmachinebmc
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -64,7 +65,7 @@ func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualM
 						"--address",
 						"0.0.0.0",
 						"--port",
-						"623",
+						strconv.Itoa(ipmiPort),
 						virtualMachineBMC.Spec.VirtualMachineNamespace,
 						virtualMachineBMC.Spec.VirtualMachineName,
 					},

--- a/pkg/virtbmc/virtbmc.go
+++ b/pkg/virtbmc/virtbmc.go
@@ -61,7 +61,7 @@ func (b *VirtBMC) Run() error {
 	b.register()
 
 	if err := b.sim.Run(); err != nil {
-		return fmt.Errorf("unable to run the ipmi simulator")
+		return fmt.Errorf("unable to run the ipmi simulator: %v", err)
 	}
 	logrus.Infof("Listen on %s:%d", b.address, b.port)
 


### PR DESCRIPTION
The listening port is updated to 10623, so does the pod's container port. The exposed service port is unchanged.

Related issue: #34