### PR TITLE
Build links between the ComputerSystem and Manager Redfish resources

### DIFF
--- a/pkg/redfish/handler.go
+++ b/pkg/redfish/handler.go
@@ -125,7 +125,7 @@ func (h *handler) GetManager() (*server.ManagerV1190Manager, error) {
 	if err != nil {
 		return nil, err
 	}
-	adapter, ok := manager.(*resourcemanager.ManagerV1190Adapter)
+	adapter, ok := manager.(*resourcemanager.ManagerAdapter)
 	if !ok {
 		return nil, fmt.Errorf("unexpected manager type: %T", manager)
 	}

--- a/pkg/resourcemanager/computer_system.go
+++ b/pkg/resourcemanager/computer_system.go
@@ -20,6 +20,22 @@ type ComputerSystemAdapter struct {
 	computerSystem *server.ComputerSystemV1220ComputerSystem
 }
 
+func (a *ComputerSystemAdapter) GetODataID() string {
+	return a.computerSystem.OdataId
+}
+
+func (a *ComputerSystemAdapter) Manage(resource ODataInterface) error {
+	panic("implement me")
+}
+
+func (a *ComputerSystemAdapter) ManagedBy(resource ODataInterface) error {
+	a.computerSystem.Links.ManagedBy = append(a.computerSystem.Links.ManagedBy, server.OdataV4IdRef{
+		OdataId: resource.GetODataID(),
+	})
+
+	return nil
+}
+
 func (a *ComputerSystemAdapter) GetComputerSystem() *server.ComputerSystemV1220ComputerSystem {
 	return a.computerSystem
 }
@@ -41,7 +57,7 @@ func (a *ComputerSystemAdapter) SetBootOverride(target server.ComputerSystemBoot
 	a.computerSystem.Boot.BootSourceOverrideTarget = target
 }
 
-func NewComputerSystem(id, name string, powerState server.ResourcePowerState) ComputerSystemInterface {
+func NewComputerSystem(id, name string, powerState server.ResourcePowerState) *ComputerSystemAdapter {
 	generatedComputerSystem := &server.ComputerSystemV1220ComputerSystem{
 		OdataContext: "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
 		OdataId:      fmt.Sprintf("/redfish/v1/Systems/%s", id),

--- a/pkg/resourcemanager/computer_system.go
+++ b/pkg/resourcemanager/computer_system.go
@@ -2,7 +2,6 @@ package resourcemanager
 
 import (
 	"fmt"
-	"time"
 
 	"kubevirt.io/kubevirtbmc/pkg/generated/redfish/server"
 	"kubevirt.io/kubevirtbmc/pkg/util"
@@ -100,52 +99,4 @@ func NewComputerSystem(id, name string, powerState server.ResourcePowerState) Co
 	}
 
 	return &ComputerSystemAdapter{computerSystem: generatedComputerSystem}
-}
-
-type ManagerInterface interface {
-	GetID() string
-}
-
-type ManagerV1190Adapter struct {
-	manager *server.ManagerV1190Manager
-}
-
-func (a *ManagerV1190Adapter) GetID() string {
-	return a.manager.Id
-}
-
-func (a *ManagerV1190Adapter) GetManager() *server.ManagerV1190Manager {
-	return a.manager
-}
-
-func NewManager(id, name string) ManagerInterface {
-	generatedManager := &server.ManagerV1190Manager{
-		OdataContext: "/redfish/v1/$metadata#Manager.Manager",
-		OdataId:      fmt.Sprintf("/redfish/v1/Managers/%s", id),
-		OdataType:    "#Manager.v1_19_2.Manager",
-		Description:  "Manager",
-		Name:         name,
-		Id:           id,
-		UUID:         "00000000-0000-0000-0000-000000000000",
-		Model:        util.Ptr("KubeVirtBMC"),
-		Status:       server.ResourceStatus{},
-		ManagerType:  "BMC",
-		Links:        server.ManagerV1190Links{},
-		Actions:      server.ManagerV1190Actions{},
-		DateTime:     util.Ptr(time.Now()),
-		EthernetInterfaces: server.OdataV4IdRef{
-			OdataId: "/redfish/v1/Managers/BMC/EthernetInterfaces",
-		},
-		LogServices: server.OdataV4IdRef{
-			OdataId: "/redfish/v1/Managers/BMC/LogServices",
-		},
-		SerialInterfaces: server.OdataV4IdRef{
-			OdataId: "/redfish/v1/Managers/BMC/SerialInterfaces",
-		},
-		VirtualMedia: server.OdataV4IdRef{
-			OdataId: "/redfish/v1/Managers/BMC/VirtualMedia",
-		},
-	}
-
-	return &ManagerV1190Adapter{manager: generatedManager}
 }

--- a/pkg/resourcemanager/generic_resource.go
+++ b/pkg/resourcemanager/generic_resource.go
@@ -1,0 +1,8 @@
+package resourcemanager
+
+type ODataInterface interface {
+	GetODataID() string
+
+	Manage(ODataInterface) error
+	ManagedBy(ODataInterface) error
+}

--- a/pkg/resourcemanager/manager.go
+++ b/pkg/resourcemanager/manager.go
@@ -16,6 +16,10 @@ type ManagerAdapter struct {
 	manager *server.ManagerV1190Manager
 }
 
+func (a *ManagerAdapter) GetODataID() string {
+	return a.manager.OdataId
+}
+
 func (a *ManagerAdapter) GetID() string {
 	return a.manager.Id
 }
@@ -24,7 +28,19 @@ func (a *ManagerAdapter) GetManager() *server.ManagerV1190Manager {
 	return a.manager
 }
 
-func NewManager(id, name string) ManagerInterface {
+func (a *ManagerAdapter) Manage(resource ODataInterface) error {
+	a.manager.Links.ManagerForServers = append(a.manager.Links.ManagerForServers, server.OdataV4IdRef{
+		OdataId: resource.GetODataID(),
+	})
+
+	return nil
+}
+
+func (a *ManagerAdapter) ManagedBy(resource ODataInterface) error {
+	panic("implement me")
+}
+
+func NewManager(id, name string) *ManagerAdapter {
 	generatedManager := &server.ManagerV1190Manager{
 		OdataContext: "/redfish/v1/$metadata#Manager.Manager",
 		OdataId:      fmt.Sprintf("/redfish/v1/Managers/%s", id),

--- a/pkg/resourcemanager/manager.go
+++ b/pkg/resourcemanager/manager.go
@@ -1,0 +1,57 @@
+package resourcemanager
+
+import (
+	"fmt"
+	"time"
+
+	"kubevirt.io/kubevirtbmc/pkg/generated/redfish/server"
+	"kubevirt.io/kubevirtbmc/pkg/util"
+)
+
+type ManagerInterface interface {
+	GetID() string
+}
+
+type ManagerAdapter struct {
+	manager *server.ManagerV1190Manager
+}
+
+func (a *ManagerAdapter) GetID() string {
+	return a.manager.Id
+}
+
+func (a *ManagerAdapter) GetManager() *server.ManagerV1190Manager {
+	return a.manager
+}
+
+func NewManager(id, name string) ManagerInterface {
+	generatedManager := &server.ManagerV1190Manager{
+		OdataContext: "/redfish/v1/$metadata#Manager.Manager",
+		OdataId:      fmt.Sprintf("/redfish/v1/Managers/%s", id),
+		OdataType:    "#Manager.v1_19_2.Manager",
+		Description:  "Manager",
+		Name:         name,
+		Id:           id,
+		UUID:         "00000000-0000-0000-0000-000000000000",
+		Model:        util.Ptr("KubeVirtBMC"),
+		Status:       server.ResourceStatus{},
+		ManagerType:  "BMC",
+		Links:        server.ManagerV1190Links{},
+		Actions:      server.ManagerV1190Actions{},
+		DateTime:     util.Ptr(time.Now()),
+		EthernetInterfaces: server.OdataV4IdRef{
+			OdataId: "/redfish/v1/Managers/BMC/EthernetInterfaces",
+		},
+		LogServices: server.OdataV4IdRef{
+			OdataId: "/redfish/v1/Managers/BMC/LogServices",
+		},
+		SerialInterfaces: server.OdataV4IdRef{
+			OdataId: "/redfish/v1/Managers/BMC/SerialInterfaces",
+		},
+		VirtualMedia: server.OdataV4IdRef{
+			OdataId: "/redfish/v1/Managers/BMC/VirtualMedia",
+		},
+	}
+
+	return &ManagerAdapter{manager: generatedManager}
+}


### PR DESCRIPTION
Now that a ComputerSystem resource is `ManagedBy` a Manager resource:

```
$ curl -sSfL -H "X-Auth-Token: d40314aa8ef6bf03daebe42166470f9047fbefd6a958cb035ae70a630382d489" http://127.0.0.1:55247/redfish/v1/Systems/1 | jq .
{
  "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
  "@odata.id": "/redfish/v1/Systems/1",
  "@odata.type": "#ComputerSystem.v1_22_0.ComputerSystem",
  "Actions": {
    "#ComputerSystem.AddResourceBlock": {},
    "#ComputerSystem.Decommission": {},
    "#ComputerSystem.RemoveResourceBlock": {},
    "#ComputerSystem.Reset": {
      "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
      "title": "Reset"
    },
    "#ComputerSystem.SetDefaultBootOrder": {}
  },
  "AssetTag": "",
  "Bios": {},
  "Boot": {
    "BootOptions": {},
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "Legacy",
    "BootSourceOverrideTarget": "Hdd",
    "Certificates": {}
  },
  "BootProgress": {},
  "Certificates": {},
  "Composition": {},
  "Description": "Computer System",
  "EthernetInterfaces": {},
  "FabricAdapters": {},
  "GraphicalConsole": {},
  "GraphicsControllers": {},
  "HostWatchdogTimer": {
    "FunctionEnabled": false,
    "Status": {},
    "TimeoutAction": ""
  },
  "HostedServices": {
    "StorageServices": {}
  },
  "Id": "1",
  "IdlePowerSaver": {},
  "IndicatorLED": "Unknown",
  "KeyManagement": {
    "KMIPCertificates": {}
  },
  "LastResetTime": "0001-01-01T00:00:00Z",
  "Links": {
    "HostingComputerSystem": {},
    "ManagedBy": [
      {
        "@odata.id": "/redfish/v1/Managers/BMC"
      }
    ]
  },
  "LogServices": {},
  "Manufacturer": "KubeVirt",
  "Memory": {},
  "MemoryDomains": {},
  "MemorySummary": {
    "Metrics": {},
    "Status": {},
    "TotalSystemMemoryGiB": 0
  },
  "Model": "KubeVirt",
  "Name": "default/test-vm",
  "NetworkInterfaces": {
    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces"
  },
  "OperatingSystem": "/redfish/v1/Systems/1/OperatingSystem",
  "PartNumber": "",
  "PowerState": "On",
  "ProcessorSummary": {
    "Count": 0,
    "Metrics": {},
    "Status": {}
  },
  "Processors": {},
  "SKU": "",
  "SecureBoot": {},
  "SerialConsole": {
    "IPMI": {},
    "SSH": {},
    "Telnet": {}
  },
  "SerialNumber": "000000000000",
  "SimpleStorage": {
    "@odata.id": "/redfish/v1/Systems/1/SimpleStorage"
  },
  "Status": {},
  "Storage": {
    "@odata.id": "/redfish/v1/Systems/1/Storage"
  },
  "SystemType": "Virtual",
  "USBControllers": {},
  "UUID": "00000000-0000-0000-0000-000000000000",
  "VirtualMedia": {
    "@odata.id": "/redfish/v1/Systems/1/VirtualMedia"
  },
  "VirtualMediaConfig": {}
}
```

A Manager resource `Manage`s a ComputerSystem resource:

```
$ curl -sSfL -H "X-Auth-Token: d40314aa8ef6bf03daebe42166470f9047fbefd6a958cb035ae70a6
30382d489" http://127.0.0.1:55247/redfish/v1/Managers/BMC | jq .
{
  "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
  "@odata.id": "/redfish/v1/Managers/BMC",
  "@odata.type": "#Manager.v1_19_2.Manager",
  "Actions": {
    "#Manager.ForceFailover": {},
    "#Manager.ModifyRedundancySet": {},
    "#Manager.Reset": {},
    "#Manager.ResetToDefaults": {}
  },
  "AdditionalFirmwareVersions": {},
  "Certificates": {},
  "CommandShell": {},
  "DateTime": "2025-03-05T15:11:09.401107411Z",
  "DaylightSavingTime": {
    "EndDateTime": "0001-01-01T00:00:00Z",
    "StartDateTime": "0001-01-01T00:00:00Z"
  },
  "DedicatedNetworkPorts": {},
  "Description": "Manager",
  "EthernetInterfaces": {
    "@odata.id": "/redfish/v1/Managers/BMC/EthernetInterfaces"
  },
  "GraphicalConsole": {},
  "HostInterfaces": {},
  "Id": "BMC",
  "LastResetTime": "0001-01-01T00:00:00Z",
  "Links": {
    "ActiveSoftwareImage": {},
    "ManagerForServers": [
      {
        "@odata.id": "/redfish/v1/Systems/1"
      }
    ],
    "ManagerInChassis": {},
    "SelectedNetworkPort": {}
  },
  "Location": {
    "PartLocation": {},
    "PhysicalAddress": {},
    "Placement": {},
    "PostalAddress": {}
  },
  "LogServices": {
    "@odata.id": "/redfish/v1/Managers/BMC/LogServices"
  },
  "ManagerDiagnosticData": {},
  "ManagerType": "BMC",
  "Model": "KubeVirtBMC",
  "Name": "Manager",
  "NetworkProtocol": {},
  "RemoteAccountService": {},
  "SecurityPolicy": {},
  "SerialConsole": {},
  "SerialInterfaces": {
    "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces"
  },
  "SharedNetworkPorts": {},
  "Status": {},
  "USBPorts": {},
  "UUID": "00000000-0000-0000-0000-000000000000",
  "VirtualMedia": {
    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia"
  }
}
```

Related issue: #70 