### PR TITLE
ci: sanitize version for image tag

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,7 +15,7 @@ jobs:
       REPO: starbops
       MANAGER: virtbmc-controller
       AGENT: virtbmc
-      VERSION: ${{ github.event.pull_request.head.ref }}-head
+      VERSION: pr-${{ github.event.number }}-head
       GIT_COMMIT: ${{ github.sha }}
     steps:
     - name: Check out repository code
@@ -67,4 +67,3 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
     - name: Run end-to-end testing
       run: make local-e2e-test
-


### PR DESCRIPTION
The head branch name of a pull request might contain invalid characters for image tag names. We need to sanitize the version string before using it for the image tag.