### PR TITLE
[Draft] Implement VirtualMachineBMC v1beta1 Controller

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -25,6 +25,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+  controller: true
   domain: kubevirt.io
   group: bmc
   kind: VirtualMachineBMC

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module kubevirt.io/kubevirtbmc
 go 1.23.2
 
 require (
+	github.com/go-logr/logr v1.4.1
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/onsi/ginkgo/v2 v2.15.0
@@ -29,7 +30,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/internal/controller/bmc/constants.go
+++ b/internal/controller/bmc/constants.go
@@ -1,0 +1,30 @@
+package bmc
+
+const (
+	// Finalizer constants
+	FinalizerName = "bmc.kubevirt.io/finalizer"
+
+	// Label and name suffix constants
+	AppLabelKey          = "app"
+	BMCProxyLabelSuffix  = "-bmc-proxy"
+	BMCServiceNameSuffix = "-bmc-service"
+
+	// Container and port constants
+	BMCContainerName = "bmc-proxy"
+	BMCPortName      = "bmc"
+	BMCPortNumber    = 623
+
+	// Auth secret mount constants
+	AuthSecretVolumeName = "auth-secret"
+	AuthSecretMountPath  = "/etc/bmc-auth"
+
+	// Condition and message constants
+	ConditionReady    = "Ready"
+	ReasonBMCReady    = "BMCReady"
+	ReasonBMCNotReady = "BMCNotReady"
+
+	MsgBMCReady    = "BMC is ready and operational."
+	MsgBMCNotReady = "BMC is not ready yet, waiting for deployment to stabilize. " +
+		"Ensure the BMC proxy is running and has the correct configuration. " +
+		"Check logs for more details."
+)

--- a/internal/controller/bmc/controller.go
+++ b/internal/controller/bmc/controller.go
@@ -1,0 +1,164 @@
+package bmc
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	bmcv1beta1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+)
+
+type VirtualMachineBMCReconciler struct {
+	client.Client
+	Scheme         *runtime.Scheme
+	AgentImageName string
+	AgentImageTag  string
+}
+
+func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("vmBMC", req.NamespacedName)
+
+	// 1. Fetch the resource
+	vmBMC := &bmcv1beta1.VirtualMachineBMC{}
+	if err := r.Get(ctx, req.NamespacedName, vmBMC); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object deleted, nothing to do
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Failed to fetch VirtualMachineBMC")
+		return ctrl.Result{}, err
+	}
+
+	// 2. Handle finalizer/deletion
+	if result, err := r.handleFinalizer(ctx, vmBMC, logger); result != nil || err != nil {
+		return *result, err
+	}
+
+	// 3. Validate references to VM and Secret
+	vm, secret, result, err := r.validateReferences(ctx, vmBMC, logger)
+	if result != nil || err != nil {
+		return *result, err
+	}
+
+	// 4. Reconcile Deployment and Service
+	svc := r.serviceForVirtualMachineBMC(vmBMC)
+	deploy := r.deploymentForVirtualMachineBMC(vmBMC, vm, secret)
+
+	foundSvc := &corev1.Service{}
+	foundDeploy := &appsv1.Deployment{}
+
+	// Reconcile Service
+	if err := r.reconcileService(ctx, vmBMC, svc, foundSvc, logger); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Reconcile Deployment
+	if err := r.reconcileDeployment(ctx, vmBMC, deploy, foundDeploy, logger); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// 5. Update Status
+	if _, err := r.updateStatus(ctx, vmBMC, foundSvc, foundDeploy, logger); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// 6. Requeue every 5 minutes
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+func (r *VirtualMachineBMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&bmcv1beta1.VirtualMachineBMC{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Watches(
+			&kubevirtv1.VirtualMachine{},
+			handler.EnqueueRequestsFromMapFunc(mapVMToBMCs(r.Client)),
+		).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(mapSecretToBMCs(r.Client)),
+		).
+		Complete(r)
+}
+
+func (r *VirtualMachineBMCReconciler) reconcileService(ctx context.Context, _ *bmcv1beta1.VirtualMachineBMC, desired *corev1.Service, found *corev1.Service, logger logr.Logger) error {
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, found)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Creating BMC Service", "name", desired.Name)
+			return r.Create(ctx, desired)
+		}
+		logger.Error(err, "Failed to get Service")
+		return err
+	}
+
+	// Compare mutable fields only
+	needUpdate := false
+	updated := found.DeepCopy()
+
+	if !equalPorts(found.Spec.Ports, desired.Spec.Ports) {
+		updated.Spec.Ports = desired.Spec.Ports
+		needUpdate = true
+	}
+
+	if !equalMap(found.Spec.Selector, desired.Spec.Selector) {
+		updated.Spec.Selector = desired.Spec.Selector
+		needUpdate = true
+	}
+
+	if needUpdate {
+		logger.Info("Updating BMC Service", "name", desired.Name)
+		return r.Update(ctx, updated)
+	}
+
+	return nil
+}
+
+func (r *VirtualMachineBMCReconciler) reconcileDeployment(ctx context.Context, _ *bmcv1beta1.VirtualMachineBMC, desired *appsv1.Deployment, found *appsv1.Deployment, logger logr.Logger) error {
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, found)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Creating BMC Deployment", "name", desired.Name)
+			return r.Create(ctx, desired)
+		}
+		logger.Error(err, "Failed to get Deployment")
+		return err
+	}
+
+	// Compare key mutable fields
+	updated := found.DeepCopy()
+	needUpdate := false
+
+	if !equalMap(found.Spec.Template.Labels, desired.Spec.Template.Labels) {
+		updated.Spec.Template.Labels = desired.Spec.Template.Labels
+		needUpdate = true
+	}
+
+	if len(found.Spec.Template.Spec.Containers) > 0 && len(desired.Spec.Template.Spec.Containers) > 0 {
+		foundC := found.Spec.Template.Spec.Containers[0]
+		desiredC := desired.Spec.Template.Spec.Containers[0]
+
+		if foundC.Image != desiredC.Image || !equalEnv(foundC.Env, desiredC.Env) || !equalMounts(foundC.VolumeMounts, desiredC.VolumeMounts) {
+			updated.Spec.Template.Spec.Containers[0] = desiredC
+			needUpdate = true
+		}
+	}
+
+	if needUpdate {
+		logger.Info("Updating BMC Deployment", "name", desired.Name)
+		return r.Update(ctx, updated)
+	}
+
+	return nil
+}

--- a/internal/controller/bmc/finalizer.go
+++ b/internal/controller/bmc/finalizer.go
@@ -1,0 +1,67 @@
+package bmc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	bmcv1beta1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+)
+
+// handleFinalizer ensures the finalizer is added or removed appropriately.
+func (r *VirtualMachineBMCReconciler) handleFinalizer(ctx context.Context, bmc *bmcv1beta1.VirtualMachineBMC, log logr.Logger) (*ctrl.Result, error) {
+	if bmc.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Add finalizer if not present
+		if !controllerutil.ContainsFinalizer(bmc, FinalizerName) {
+			log.Info("Adding finalizer")
+			controllerutil.AddFinalizer(bmc, FinalizerName)
+			if err := r.Update(ctx, bmc); err != nil {
+				log.Error(err, "Failed to add finalizer")
+				return &ctrl.Result{}, err
+			}
+		}
+	} else {
+		// Handle deletion
+		if controllerutil.ContainsFinalizer(bmc, FinalizerName) {
+			log.Info("Cleaning up owned resources before deletion")
+			if err := r.cleanupOwnedResources(ctx, bmc, log); err != nil {
+				return &ctrl.Result{}, err
+			}
+			controllerutil.RemoveFinalizer(bmc, FinalizerName)
+			if err := r.Update(ctx, bmc); err != nil {
+				log.Error(err, "Failed to remove finalizer")
+				return &ctrl.Result{}, err
+			}
+		}
+		return &ctrl.Result{}, nil
+	}
+	return nil, nil
+}
+
+// cleanupOwnedResources deletes the Deployment and Service owned by the BMC
+func (r *VirtualMachineBMCReconciler) cleanupOwnedResources(ctx context.Context, bmc *bmcv1beta1.VirtualMachineBMC, log logr.Logger) error {
+	deploy := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: bmc.Name + "-bmc-proxy", Namespace: bmc.Namespace}, deploy); err == nil {
+		log.Info("Deleting Deployment")
+		if err := r.Delete(ctx, deploy); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete Deployment: %w", err)
+		}
+	}
+
+	svc := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: bmc.Name + "-bmc-service", Namespace: bmc.Namespace}, svc); err == nil {
+		log.Info("Deleting Service")
+		if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete Service: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/bmc/helpers.go
+++ b/internal/controller/bmc/helpers.go
@@ -1,0 +1,33 @@
+package bmc
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// equalMap compares two string maps.
+func equalMap(a, b map[string]string) bool {
+	return equality.Semantic.DeepEqual(a, b)
+}
+
+// equalPorts compares two sets of container or service ports.
+func equalPorts(a, b []corev1.ServicePort) bool {
+	return equality.Semantic.DeepEqual(a, b)
+}
+
+// equalEnv compares two sets of EnvVars.
+func equalEnv(a, b []corev1.EnvVar) bool {
+	return equality.Semantic.DeepEqual(a, b)
+}
+
+func equalMounts(a, b []corev1.VolumeMount) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name || a[i].MountPath != b[i].MountPath || a[i].SubPath != b[i].SubPath {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/bmc/references.go
+++ b/internal/controller/bmc/references.go
@@ -1,0 +1,49 @@
+package bmc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	bmcv1beta1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// validateReferences fetches and validates the referenced VM and Secret.
+// Returns nil for both if not found, with an early Requeue result.
+func (r *VirtualMachineBMCReconciler) validateReferences(ctx context.Context, vmBMC *bmcv1beta1.VirtualMachineBMC, logger logr.Logger) (*kubevirtv1.VirtualMachine, *corev1.Secret, *ctrl.Result, error) {
+	if vmBMC.Spec.VirtualMachineRef == nil || vmBMC.Spec.VirtualMachineRef.Name == "" {
+		r.setCondition(ctx, vmBMC, bmcv1beta1.ConditionReady, metav1.ConditionFalse, "VirtualMachineRefMissing", "VirtualMachineRef is required and must specify a name.")
+		return nil, nil, &ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+	var vm *kubevirtv1.VirtualMachine
+	if err := r.Get(ctx, types.NamespacedName{Namespace: vmBMC.Namespace, Name: vmBMC.Spec.VirtualMachineRef.Name}, vm); err != nil {
+		if errors.IsNotFound(err) {
+			r.setCondition(ctx, vmBMC, bmcv1beta1.ConditionReady, metav1.ConditionFalse, "VirtualMachineNotFound", fmt.Sprintf("Referenced VirtualMachine '%s' not found.", vmBMC.Spec.VirtualMachineRef.Name))
+			return nil, nil, &ctrl.Result{RequeueAfter: time.Minute}, nil
+		}
+		logger.Error(err, "Failed to get VirtualMachine")
+		return nil, nil, &ctrl.Result{}, err
+	}
+	if vmBMC.Spec.AuthSecretRef == nil || vmBMC.Spec.AuthSecretRef.Name == "" {
+		r.setCondition(ctx, vmBMC, bmcv1beta1.ConditionReady, metav1.ConditionFalse, "AuthSecretRefMissing", "AuthSecretRef is required and must specify a name.")
+		return nil, nil, &ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: vmBMC.Namespace, Name: vmBMC.Spec.AuthSecretRef.Name}, secret); err != nil {
+		if errors.IsNotFound(err) {
+			r.setCondition(ctx, vmBMC, bmcv1beta1.ConditionReady, metav1.ConditionFalse, "AuthSecretNotFound", fmt.Sprintf("Referenced Secret '%s' not found.", vmBMC.Spec.AuthSecretRef.Name))
+			return nil, nil, &ctrl.Result{RequeueAfter: time.Minute}, nil
+		}
+		logger.Error(err, "Failed to get Secret")
+		return nil, nil, &ctrl.Result{}, err
+	}
+	r.setCondition(ctx, vmBMC, bmcv1beta1.ConditionReady, metav1.ConditionUnknown, "ReferencesValidated", "All required references are found.")
+	return vm, secret, nil, nil
+}

--- a/internal/controller/bmc/resources.go
+++ b/internal/controller/bmc/resources.go
@@ -1,0 +1,115 @@
+package bmc
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	bmcv1beta1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+)
+
+// serviceForVirtualMachineBMC returns the desired Service object.
+func (r *VirtualMachineBMCReconciler) serviceForVirtualMachineBMC(bmc *bmcv1beta1.VirtualMachineBMC) *corev1.Service {
+	labels := map[string]string{
+		AppLabelKey: bmc.Name + BMCProxyLabelSuffix,
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bmc.Name + BMCServiceNameSuffix,
+			Namespace: bmc.Namespace,
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(bmc, bmcv1beta1.GroupVersion.WithKind("VirtualMachineBMC")),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: labels,
+			Ports: []corev1.ServicePort{
+				{
+					Name:     BMCPortName,
+					Port:     BMCPortNumber,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+}
+
+// deploymentForVirtualMachineBMC returns the desired Deployment object.
+func (r *VirtualMachineBMCReconciler) deploymentForVirtualMachineBMC(bmc *bmcv1beta1.VirtualMachineBMC, vm *kubevirtv1.VirtualMachine, secret *corev1.Secret) *appsv1.Deployment {
+	labels := map[string]string{
+		AppLabelKey: bmc.Name + BMCProxyLabelSuffix,
+	}
+	replicas := int32(1)
+
+	image := r.AgentImageName
+	if r.AgentImageTag != "" {
+		image = fmt.Sprintf("%s:%s", r.AgentImageName, r.AgentImageTag)
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bmc.Name + BMCProxyLabelSuffix,
+			Namespace: bmc.Namespace,
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(bmc, bmcv1beta1.GroupVersion.WithKind("VirtualMachineBMC")),
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  BMCContainerName,
+							Image: image,
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          BMCPortName,
+									ContainerPort: BMCPortNumber,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "VIRTUALMACHINE_NAME",
+									Value: vm.Name,
+								},
+								{
+									Name:  "VIRTUALMACHINE_NAMESPACE",
+									Value: vm.Namespace,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      AuthSecretVolumeName,
+									MountPath: AuthSecretMountPath,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: AuthSecretVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: secret.Name,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/bmc/status.go
+++ b/internal/controller/bmc/status.go
@@ -1,0 +1,83 @@
+package bmc
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	bmcv1beta1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+)
+
+// setCondition updates or inserts a status condition on the VirtualMachineBMC.
+func (r *VirtualMachineBMCReconciler) setCondition(ctx context.Context, bmc *bmcv1beta1.VirtualMachineBMC, conditionType string, status metav1.ConditionStatus, reason, message string) {
+	newCond := metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: bmc.Generation,
+	}
+
+	// Check for an existing condition to update
+	for i, cond := range bmc.Status.Conditions {
+		if cond.Type == conditionType {
+			if cond.Status != status || cond.Reason != reason || cond.Message != message {
+				bmc.Status.Conditions[i] = newCond
+			}
+			return
+		}
+	}
+
+	// Condition not found, add it
+	bmc.Status.Conditions = append(bmc.Status.Conditions, newCond)
+}
+
+// updateStatus updates .status.ClusterIP and .status.conditions for the BMC
+func (r *VirtualMachineBMCReconciler) updateStatus(ctx context.Context, bmc *bmcv1beta1.VirtualMachineBMC, svc *corev1.Service, deploy *appsv1.Deployment, logger logr.Logger) (*ctrl.Result, error) {
+	needUpdate := false
+
+	// Update ClusterIP if changed
+	if svc.Spec.ClusterIP != "" && bmc.Status.ClusterIP != svc.Spec.ClusterIP {
+		bmc.Status.ClusterIP = svc.Spec.ClusterIP
+		needUpdate = true
+	}
+
+	// Determine desired condition
+	newStatus := metav1.ConditionFalse
+	reason := ReasonBMCNotReady
+	message := MsgBMCNotReady
+
+	if deploy != nil && deploy.Spec.Replicas != nil && deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+		newStatus = metav1.ConditionTrue
+		reason = ReasonBMCReady
+		message = MsgBMCReady
+	}
+
+	// Check if current condition is different
+	current := metav1.ConditionUnknown
+	for _, cond := range bmc.Status.Conditions {
+		if cond.Type == ConditionReady {
+			current = cond.Status
+			break
+		}
+	}
+
+	if current != newStatus {
+		r.setCondition(ctx, bmc, ConditionReady, newStatus, reason, message)
+		needUpdate = true
+	}
+
+	if needUpdate {
+		if err := r.Status().Update(ctx, bmc); err != nil {
+			logger.Error(err, "failed to update VirtualMachineBMC status")
+			return &ctrl.Result{}, err
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/controller/bmc/watchers.go
+++ b/internal/controller/bmc/watchers.go
@@ -1,0 +1,67 @@
+package bmc
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	bmcv1beta1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func mapVMToBMCs(c client.Client) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		vm, ok := obj.(*kubevirtv1.VirtualMachine)
+		if !ok {
+			return nil
+		}
+
+		var bmcList bmcv1beta1.VirtualMachineBMCList
+		if err := c.List(ctx, &bmcList, client.InNamespace(vm.Namespace)); err != nil {
+			return nil
+		}
+
+		var reqs []reconcile.Request
+		for _, bmc := range bmcList.Items {
+			if bmc.Spec.VirtualMachineRef != nil && bmc.Spec.VirtualMachineRef.Name == vm.Name {
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: bmc.Namespace,
+						Name:      bmc.Name,
+					},
+				})
+			}
+		}
+		return reqs
+	}
+}
+
+func mapSecretToBMCs(c client.Client) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		secret, ok := obj.(*corev1.Secret)
+		if !ok {
+			return nil
+		}
+
+		var bmcList bmcv1beta1.VirtualMachineBMCList
+		if err := c.List(ctx, &bmcList, client.InNamespace(secret.Namespace)); err != nil {
+			return nil
+		}
+
+		var reqs []reconcile.Request
+		for _, bmc := range bmcList.Items {
+			if bmc.Spec.AuthSecretRef != nil && bmc.Spec.AuthSecretRef.Name == secret.Name {
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: bmc.Namespace,
+						Name:      bmc.Name,
+					},
+				})
+			}
+		}
+		return reqs
+	}
+}


### PR DESCRIPTION
## Implemented:
- Modular controller logic under internal/controller/bmc/
- Files: controller.go, finalizer.go, references.go, resources.go, status.go, watchers.go, constants.go
- Controller manages Deployments and Services per VM-BMC pair
- Extracted constants and labels into a shared file

### Next Steps:

- Add unit tests using Ginkgo, organized by component
- Verify RBAC markers and controller-gen annotations