### PR TITLE
ci: pin yamale version to 6.0.0 for ct ci

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -27,6 +27,8 @@ jobs:
         check-latest: true
     - name: Set up chart-testing
       uses: helm/chart-testing-action@v2
+      with:
+        yamale_version: "6.0.0"
     - name: Run chart-testing (list-changed)
       id: list-changed
       run: |


### PR DESCRIPTION
This PR tries to fix up recent chart CI workflow failures, e.g., https://github.com/starbops/kubevirtbmc/actions/runs/19167891423/job/54864954127