### PR TITLE
Fix: Add the dynamic creation of sa and rb for each CR

### DIFF
--- a/internal/controller/virtualmachinebmc/controller.go
+++ b/internal/controller/virtualmachinebmc/controller.go
@@ -49,9 +49,7 @@ type VirtualMachineBMCReconciler struct {
 }
 
 const (
-	serviceAccountName = "kubevirtbmc-virtbmc"
-	clusterRoleName    = "kubevirtbmc-virtbmc-role"
-	roleBindingName    = "kubevirtbmc-virtbmc-rolebinding"
+	clusterRoleName = "kubevirtbmc-virtbmc-role"
 )
 
 var (
@@ -60,6 +58,7 @@ var (
 )
 
 func (r *VirtualMachineBMCReconciler) constructServiceAccount(virtualMachineBMC *bmcv1.VirtualMachineBMC) *corev1.ServiceAccount {
+	serviceAccountName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
@@ -70,6 +69,8 @@ func (r *VirtualMachineBMCReconciler) constructServiceAccount(virtualMachineBMC 
 }
 
 func (r *VirtualMachineBMCReconciler) constructRoleBinding(virtualMachineBMC *bmcv1.VirtualMachineBMC) *rbacv1.RoleBinding {
+	serviceAccountName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+	roleBindingName := fmt.Sprintf("%s-virtbmc-rolebinding", virtualMachineBMC.Spec.VirtualMachineRef.Name)
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleBindingName,
@@ -131,6 +132,7 @@ func (r *VirtualMachineBMCReconciler) ensureRBACResources(ctx context.Context, v
 
 func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualMachineBMC *bmcv1.VirtualMachineBMC) *corev1.Pod {
 	name := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+	serviceAccountName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/virtualmachinebmc/controller_test.go
+++ b/internal/controller/virtualmachinebmc/controller_test.go
@@ -18,6 +18,7 @@ package virtualmachinebmc
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,6 +44,9 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 	)
 
 	Context("When creating a VirtualMachineBMC", func() {
+		serviceAccountName := fmt.Sprintf("%s-virtbmc", testVMName)
+		roleBindingName := fmt.Sprintf("%s-virtbmc-rolebinding", testVMName)
+
 		It("Should create RBAC resources, Pod and Service", func() {
 			ctx := context.Background()
 
@@ -252,7 +256,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 
 			By("Verifying that the controller reconciles and creates RBAC resources")
 			saLookupKey := types.NamespacedName{
-				Name:      serviceAccountName,
+				Name:      "late-created-vm-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
 			createdSA := &corev1.ServiceAccount{}
@@ -262,7 +266,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			rbLookupKey := types.NamespacedName{
-				Name:      roleBindingName,
+				Name:      "late-created-vm-virtbmc-rolebinding",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
 			createdRB := &rbacv1.RoleBinding{}
@@ -279,7 +283,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 
 			Expect(createdPod.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, "test-vmbmc-late-vm"))
 			Expect(createdPod.Labels).To(HaveKeyWithValue(VMNameLabel, "late-created-vm"))
-			Expect(createdPod.Spec.ServiceAccountName).To(Equal(serviceAccountName))
+			Expect(createdPod.Spec.ServiceAccountName).To(Equal("late-created-vm-virtbmc"))
 
 			By("Verifying that the Service is now created")
 			svcLookupKey := types.NamespacedName{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,11 +19,15 @@ import (
 )
 
 const (
-	serviceAccountName = "kubevirtbmc-virtbmc"
-	roleBindingName    = "kubevirtbmc-virtbmc-rolebinding"
+	vmName      = "test-vm"
+	vmNamespace = "default"
+	bmcName     = "test-bmc"
 )
 
 var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
+
+	serviceAccountName := fmt.Sprintf("%s-virtbmc", vmName)
+	roleBindingName := fmt.Sprintf("%s-virtbmc-rolebinding", vmName)
 
 	It("should run successfully", func() {
 		By("validating the controller-manager pod exists")
@@ -74,8 +79,8 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 		Specify("a VirtualMachine", func() {
 			vm = kubevirtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vm",
-					Namespace: "default",
+					Name:      vmName,
+					Namespace: vmNamespace,
 				},
 				Spec: kubevirtv1.VirtualMachineSpec{
 					Running: func(b bool) *bool { return &b }(true),
@@ -98,7 +103,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 		It("should allow the user to create a VirtualMachineBMC in the same namespace", func() {
 			createdVMBMC = &bmcv1.VirtualMachineBMC{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      strings.Join([]string{vm.Namespace, vm.Name}, "-"),
+					Name:      bmcName,
 					Namespace: vm.Namespace,
 				},
 				Spec: bmcv1.VirtualMachineBMCSpec{


### PR DESCRIPTION
Tracking issue: https://github.com/starbops/kubevirtbmc/issues/116

- Keep the owner reference as it is and leverage the dynamic creation of `sa` and `rb` for each bmc resource