### PR TITLE
docs:  refractor current readme.md [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <img src="docs/assets/images/kubevirtbmc_banner_tagline_transparent.png" alt="KubeVirtBMC"/>
 </div>
 
-[![main build and publish workflow](https://github.com/starbops/kubevirtbmc/actions/workflows/main.yml/badge.svg)](https://github.com/starbops/kubevirtbmc/actions/workflows/main.yml)
-[![release](https://img.shields.io/github/v/release/starbops/kubevirtbmc)](https://github.com/starbops/kubevirtbmc/releases)
+[![main build and publish workflow](https://github.com/kubevirtbmc/kubevirtbmc/actions/workflows/main.yml/badge.svg)](https://github.com/starbops/kubevirtbmc/actions/workflows/main.yml)
+[![release](https://img.shields.io/github/v/release/kubevirtbmc/kubevirtbmc)](https://github.com/kubevirtbmc/kubevirtbmc/releases)
 [![Discord](https://img.shields.io/discord/1436578911613091850?style=flat&label=Discord&color=7289da)](https://discord.gg/k5hT9GDQkY)
 
 KubeVirtBMC provides **out-of-band management** for [KubeVirt](https://github.com/kubevirt/kubevirt) virtual machines on Kubernetes via [IPMI](https://www.intel.com.tw/content/www/tw/zh/products/docs/servers/ipmi/ipmi-second-gen-interface-spec-v2-rev1-1.html) and [Redfish](https://www.dmtf.org/standards/redfish)—power on/off, reset, and set boot device. Built for [Tinkerbell](https://github.com/tinkerbell/tink)/[Seeder](https://github.com/harvester/seeder) and compatible with any tooling that speaks IPMI or Redfish.


### PR DESCRIPTION
- After [this PR](https://github.com/kubevirtbmc/docs/pull/1), Kubevirtbmc docs is live at docs.kubevirtbmc.io, Therefore, current `readme.md` needs to be changed and should have only necessary core stuff. 