### PR TITLE
chore: bump chart to 0.4.1 with app version v0.7.1

### DIFF
--- a/deploy/charts/kubevirtbmc/Chart.yaml
+++ b/deploy/charts/kubevirtbmc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kubevirtbmc
-version: 0.4.0
+version: 0.4.1
 description: A Helm chart for KubeVirtBMC
 type: application
 keywords:
@@ -10,11 +10,11 @@ keywords:
 - bmc
 - ipmi
 - redfish
-home: https://github.com/starbops/kubevirtbmc
+home: https://kubevirtbmc.io
 sources:
-- https://github.com/starbops/kubevirtbmc
+- https://github.com/kubevirtbmc/kubevirtbmc
 maintainers:
 - name: starbops
   email: starbops@hey.com
   url: https://www.zespre.com
-appVersion: v0.7.0
+appVersion: v0.7.1


### PR DESCRIPTION
Changed the links as well.