### PR TITLE
Feat: changed pod to deployment

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - bmc.kubevirt.io
   resources:
   - virtualmachinebmcs

--- a/internal/controller/virtualmachinebmc/bmc_controller.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller.go
@@ -19,7 +19,6 @@ package virtualmachinebmc
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -132,83 +131,6 @@ func (r *VirtualMachineBMCReconciler) ensureRBACResources(ctx context.Context, v
 	return nil
 }
 
-func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualMachineBMC *bmcv1.VirtualMachineBMC) *corev1.Pod {
-	name := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
-	serviceAccountName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
-	var secretName string
-	if virtualMachineBMC.Spec.AuthSecretRef != nil {
-		secretName = virtualMachineBMC.Spec.AuthSecretRef.Name
-	}
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
-				VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
-			},
-			Name:      name,
-			Namespace: virtualMachineBMC.Namespace,
-		},
-		Spec: corev1.PodSpec{
-			ServiceAccountName: serviceAccountName,
-			Containers: []corev1.Container{
-				{
-					Name:  virtBMCContainerName,
-					Image: fmt.Sprintf("%s:%s", r.AgentImageName, r.AgentImageTag),
-					Args: []string{
-						"--address",
-						"0.0.0.0",
-						"--ipmi-port",
-						strconv.Itoa(ipmiPort),
-						"--redfish-port",
-						strconv.Itoa(redfishPort),
-						virtualMachineBMC.Namespace,
-						virtualMachineBMC.Spec.VirtualMachineRef.Name,
-					},
-					Ports: []corev1.ContainerPort{
-						{
-							Name:          ipmiPortName,
-							ContainerPort: ipmiPort,
-							Protocol:      corev1.ProtocolUDP,
-						},
-						{
-							Name:          redfishPortName,
-							ContainerPort: redfishPort,
-							Protocol:      corev1.ProtocolTCP,
-						},
-					},
-					Env: []corev1.EnvVar{
-						{
-							Name: "BMC_USERNAME",
-							ValueFrom: &corev1.EnvVarSource{
-								SecretKeyRef: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: secretName,
-									},
-									Key: bmcUserKey,
-								},
-							},
-						},
-						{
-							Name: "BMC_PASSWORD",
-							ValueFrom: &corev1.EnvVarSource{
-								SecretKeyRef: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: secretName,
-									},
-									Key: bmcPasswordKey,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return pod
-}
-
 func (r *VirtualMachineBMCReconciler) constructServiceFromVirtualMachineBMC(virtualMachineBMC *bmcv1.VirtualMachineBMC) *corev1.Service {
 	name := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
 
@@ -243,30 +165,6 @@ func (r *VirtualMachineBMCReconciler) constructServiceFromVirtualMachineBMC(virt
 	}
 
 	return svc
-}
-
-func (r *VirtualMachineBMCReconciler) deleteVirtBMCPod(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
-	log := log.FromContext(ctx)
-	podName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: virtualMachineBMC.Namespace,
-		},
-	}
-
-	if err := r.Delete(ctx, pod); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.V(1).Info("virtBMC Pod already absent", "pod", podName)
-			return nil
-		}
-
-		log.Error(err, "unable to delete virtBMC Pod", "pod", podName)
-		return err
-	}
-
-	return nil
 }
 
 func (r *VirtualMachineBMCReconciler) validateVirtualMachineExists(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (bool, error) {
@@ -365,6 +263,7 @@ func (r *VirtualMachineBMCReconciler) validateSecretExists(ctx context.Context, 
 //+kubebuilder:rbac:groups=bmc.kubevirt.io,resources=virtualmachinebmcs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=bmc.kubevirt.io,resources=virtualmachinebmcs/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=pods;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
@@ -401,8 +300,8 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if !vmExists || !secretExists {
-		if err := r.deleteVirtBMCPod(ctx, &virtualMachineBMC); err != nil {
-			log.Error(err, "unable to delete virtBMC Pod")
+		if err := r.deleteVirtBMCDeployment(ctx, &virtualMachineBMC); err != nil {
+			log.Error(err, "unable to delete virtBMC Deployment")
 			return ctrl.Result{}, err
 		}
 	}
@@ -419,19 +318,9 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Prepare the virtBMC Pod
-	pod := r.constructPodFromVirtualMachineBMC(&virtualMachineBMC)
-	if err := ctrl.SetControllerReference(&virtualMachineBMC, pod, r.Scheme); err != nil {
+	if err := r.ensureVirtBMCDeployment(ctx, &virtualMachineBMC); err != nil {
 		return ctrl.Result{}, err
 	}
-
-	// Create the virtBMC Pod on the cluster
-	if err := r.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
-		log.Error(err, "unable to create Pod for VirtualMachineBMC", "pod", pod)
-		return ctrl.Result{}, err
-	}
-
-	log.V(1).Info("created Pod for VirtualMachineBMC", "pod", pod)
 
 	// Prepare the virtBMC Service
 	svc := r.constructServiceFromVirtualMachineBMC(&virtualMachineBMC)
@@ -528,10 +417,10 @@ func (r *VirtualMachineBMCReconciler) findVirtualMachineBMCsForSecretAndVM(ctx c
 		case *corev1.Secret:
 			if vmBMC.Spec.AuthSecretRef != nil && vmBMC.Spec.AuthSecretRef.Name == o.GetName() {
 				vmBMCCopy := vmBMC.DeepCopy()
-				if err := r.deleteVirtBMCPod(ctx, vmBMCCopy); err != nil {
-					log.Error(err, "unable to delete virtBMC Pod during Secret change", "vmBMC", vmBMC.Name)
+				if err := r.rolloutRestartVirtBMCDeployment(ctx, vmBMCCopy); err != nil {
+					log.Error(err, "unable to restart virtBMC Deployment during Secret change", "vmBMC", vmBMC.Name)
 				}
-				log.Info("Deleted virtBMC Pod after Secret change")
+				log.Info("Restarted virtBMC deployment after Secret change")
 
 				match = true
 			}

--- a/internal/controller/virtualmachinebmc/bmc_controller_test.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,7 +49,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 		serviceAccountName := fmt.Sprintf("%s-virtbmc", testVMName)
 		roleBindingName := fmt.Sprintf("%s-virtbmc-rolebinding", testVMName)
 
-		It("Should create RBAC resources, Pod and Service ", func() {
+		It("Should create RBAC resources, Deployment and Service ", func() {
 			ctx := context.Background()
 
 			By("Creating the referenced VirtualMachine first")
@@ -132,23 +133,25 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(createdRB.Subjects).To(HaveLen(1))
 			Expect(createdRB.Subjects[0].Name).To(Equal(serviceAccountName))
 
-			By("Checking that the Pod is created with correct name")
-			podLookupKey := types.NamespacedName{
+			By("Checking that the Deployment is created with correct name")
+			deploymentLookupKey := types.NamespacedName{
 				Name:      testVMName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
-			createdPod := &corev1.Pod{}
+			createdDeployment := &appsv1.Deployment{}
 
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, createdPod)
+				err := k8sClient.Get(ctx, deploymentLookupKey, createdDeployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(createdPod.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
-			Expect(createdPod.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
-			Expect(createdPod.Spec.ServiceAccountName).To(Equal(serviceAccountName))
-			Expect(createdPod.Spec.Containers).To(HaveLen(1))
-			Expect(createdPod.Spec.Containers[0].Name).To(Equal(virtBMCContainerName))
+			Expect(createdDeployment.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
+			Expect(createdDeployment.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
+			Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
+			Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
+			Expect(createdDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(serviceAccountName))
+			Expect(createdDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(createdDeployment.Spec.Template.Spec.Containers[0].Name).To(Equal(virtBMCContainerName))
 
 			By("Checking that the Service is created with correct name")
 			svcLookupKey := types.NamespacedName{
@@ -371,14 +374,14 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 
-			By("Waiting for Pod to be created")
-			podLookupKey := types.NamespacedName{
+			By("Waiting for Deployment to be created")
+			deploymentLookupKey := types.NamespacedName{
 				Name:      vmName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
 			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
+				deployment := &appsv1.Deployment{}
+				err := k8sClient.Get(ctx, deploymentLookupKey, deployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
@@ -419,7 +422,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(foundCondition).To(BeTrue())
 		})
 
-		It("Should update condition and delete Pod when Secret is deleted", func() {
+		It("Should update condition and delete Deployment when Secret is deleted", func() {
 			ctx := context.Background()
 
 			vmName := "testvm-secret-delete"
@@ -492,14 +495,14 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 
-			By("Waiting for Pod to be created")
-			podLookupKey := types.NamespacedName{
+			By("Waiting for Deployment to be created")
+			deploymentLookupKey := types.NamespacedName{
 				Name:      vmName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
 			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
+				deployment := &appsv1.Deployment{}
+				err := k8sClient.Get(ctx, deploymentLookupKey, deployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
@@ -524,15 +527,15 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 
-			By("Verifying that the Pod is deleted")
+			By("Verifying that the Deployment is deleted")
 			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
+				deployment := &appsv1.Deployment{}
+				err := k8sClient.Get(ctx, deploymentLookupKey, deployment)
 				return errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 
-		It("Should delete and recreate Pod when Secret is changed", func() {
+		It("Should trigger a Deployment rollout when Secret is changed", func() {
 			ctx := context.Background()
 
 			vmName := "testvm-secret-change"
@@ -586,18 +589,21 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, virtualMachineBMC)).To(Succeed())
 
-			By("Waiting for Pod to be created")
-			podLookupKey := types.NamespacedName{
+			By("Waiting for Deployment to be created")
+			deploymentLookupKey := types.NamespacedName{
 				Name:      vmName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
-			var originalPod corev1.Pod
+			var originalDeployment appsv1.Deployment
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, &originalPod)
+				err := k8sClient.Get(ctx, deploymentLookupKey, &originalDeployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			originalPodUID := originalPod.UID
+			originalRestartedAt := ""
+			if originalDeployment.Spec.Template.Annotations != nil {
+				originalRestartedAt = originalDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+			}
 
 			By("Updating the Secret with new credentials")
 			updatedSecret := &corev1.Secret{}
@@ -608,34 +614,22 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, updatedSecret)).Should(Succeed())
 
-			By("Verifying that the old Pod is deleted")
+			By("Verifying the Deployment template gets a restart annotation")
+			var updatedDeployment appsv1.Deployment
 			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
-				if err != nil {
-					return errors.IsNotFound(err)
-				}
-				// Check if it's a different pod (new UID)
-				return pod.UID != originalPodUID
-			}, timeout, interval).Should(BeTrue())
-
-			By("Verifying that a new Pod is created by the controller")
-			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
-				if err != nil {
+				if err := k8sClient.Get(ctx, deploymentLookupKey, &updatedDeployment); err != nil {
 					return false
 				}
-				// Verify it's a new pod with different UID
-				return pod.UID != originalPodUID
+				if updatedDeployment.Spec.Template.Annotations == nil {
+					return false
+				}
+				restartedAt := updatedDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+				return restartedAt != "" && restartedAt != originalRestartedAt
 			}, timeout, interval).Should(BeTrue())
 
-			By("Verifying the new Pod has correct labels and service account")
-			var newPod corev1.Pod
-			Expect(k8sClient.Get(ctx, podLookupKey, &newPod)).Should(Succeed())
-			Expect(newPod.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, bmcName))
-			Expect(newPod.Labels).To(HaveKeyWithValue(VMNameLabel, vmName))
-			Expect(newPod.Spec.ServiceAccountName).To(Equal(vmName + "-virtbmc"))
+			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, bmcName))
+			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VMNameLabel, vmName))
+			Expect(updatedDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(vmName + "-virtbmc"))
 		})
 
 	})

--- a/internal/controller/virtualmachinebmc/deployment.go
+++ b/internal/controller/virtualmachinebmc/deployment.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualmachinebmc
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+)
+
+const (
+	defaultDesiredReplicas int32 = 1
+)
+
+func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC *bmcv1.VirtualMachineBMC) *appsv1.Deployment {
+
+	serviceAccountName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+	deploymentName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+
+	var secretName string
+	if virtualMachineBMC.Spec.AuthSecretRef != nil {
+		secretName = virtualMachineBMC.Spec.AuthSecretRef.Name
+	}
+
+	labels := map[string]string{
+		VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
+		VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: virtualMachineBMC.Namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(defaultDesiredReplicas),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccountName,
+					Containers: []corev1.Container{
+						{
+							Name:  virtBMCContainerName,
+							Image: fmt.Sprintf("%s:%s", r.AgentImageName, r.AgentImageTag),
+							Args: []string{
+								"--address",
+								"0.0.0.0",
+								"--ipmi-port",
+								strconv.Itoa(ipmiPort),
+								"--redfish-port",
+								strconv.Itoa(redfishPort),
+								virtualMachineBMC.Namespace,
+								virtualMachineBMC.Spec.VirtualMachineRef.Name,
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          ipmiPortName,
+									ContainerPort: ipmiPort,
+									Protocol:      corev1.ProtocolUDP,
+								},
+								{
+									Name:          redfishPortName,
+									ContainerPort: redfishPort,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "BMC_USERNAME",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: secretName,
+											},
+											Key: bmcUserKey,
+										},
+									},
+								},
+								{
+									Name: "BMC_PASSWORD",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: secretName,
+											},
+											Key: bmcPasswordKey,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+func (r *VirtualMachineBMCReconciler) ensureVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
+	log := log.FromContext(ctx)
+
+	desiredDeployment := r.createVirtBMCDeployment(virtualMachineBMC)
+	if err := ctrl.SetControllerReference(virtualMachineBMC, desiredDeployment, r.Scheme); err != nil {
+		return err
+	}
+
+	if err := r.Create(ctx, desiredDeployment); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existingDeployment, getErr := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
+			if getErr != nil {
+				return getErr
+			}
+			if existingDeployment == nil {
+				return nil
+			}
+
+			restartedAt := ""
+			if existingDeployment.Spec.Template.Annotations != nil {
+				restartedAt = existingDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+			}
+
+			changed := false
+			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec, desiredDeployment.Spec.Template.Spec) {
+				existingDeployment.Spec.Template.Spec = desiredDeployment.Spec.Template.Spec
+				changed = true
+			}
+			if restartedAt != "" {
+				desiredAnnotations := map[string]string{
+					"kubectl.kubernetes.io/restartedAt": restartedAt,
+				}
+				if !reflect.DeepEqual(existingDeployment.Spec.Template.Annotations, desiredAnnotations) {
+					existingDeployment.Spec.Template.Annotations = desiredAnnotations
+					changed = true
+				}
+			} else {
+				if existingDeployment.Spec.Template.Annotations != nil {
+					existingDeployment.Spec.Template.Annotations = nil
+					changed = true
+				}
+			}
+
+			if !changed {
+				return nil
+			}
+
+			if err := r.Update(ctx, existingDeployment); err != nil {
+				log.Error(err, "unable to reconcile Deployment for VirtualMachineBMC", "deployment", existingDeployment.Name)
+				return err
+			}
+			log.V(1).Info("reconciled Deployment for VirtualMachineBMC", "deployment", existingDeployment.Name)
+			return nil
+		}
+		log.Error(err, "unable to create Deployment for VirtualMachineBMC", "deployment", desiredDeployment.Name)
+		return err
+	}
+
+	log.V(1).Info("created Deployment for VirtualMachineBMC", "deployment", desiredDeployment.Name)
+	return nil
+}
+
+func (r *VirtualMachineBMCReconciler) deleteVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
+	log := log.FromContext(ctx)
+	deployment, err := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
+	if err != nil {
+		return err
+	}
+
+	if deployment == nil {
+		return nil
+	}
+
+	if err := r.Delete(ctx, deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		log.Error(err, "unable to delete virtBMC Deployment", "deployment", deployment)
+		return err
+	}
+
+	log.Info("deleted virtBMC Deployment", "deployment", deployment)
+	return nil
+}
+
+func (r *VirtualMachineBMCReconciler) rolloutRestartVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
+
+	log := log.FromContext(ctx)
+	deployment, err := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
+	if err != nil {
+		return err
+	}
+
+	if deployment == nil {
+		return nil
+	}
+
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+
+	deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+	if err := r.Update(ctx, deployment); err != nil {
+		log.Error(err, "unable to rollout restart virtBMC Deployment", "deployment", appsv1.DeploymentAvailable)
+		return err
+	}
+
+	log.Info("triggered rollout restart for virtBMC Deployment", "deployment", deployment)
+	return nil
+}
+
+func (r *VirtualMachineBMCReconciler) getVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (*appsv1.Deployment, error) {
+	log := log.FromContext(ctx)
+	deploymentName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+
+	deployment := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      deploymentName,
+		Namespace: virtualMachineBMC.Namespace,
+	}, deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		log.Error(err, "unable to get virtBMC Deployment", "deployment", deploymentName)
+		return nil, err
+	}
+
+	return deployment, nil
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}

--- a/test/util/e2e_resources.go
+++ b/test/util/e2e_resources.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,14 +25,18 @@ const (
 	E2ESecretName              = "bmc-credentials-secret"
 	E2EBMCName                 = "test-bmc"
 	E2ENamespace               = "default"
-	E2EAgentPodName            = E2EVMName + "-virtbmc"
+	E2EAgentDeploymentName     = E2EVMName + "-virtbmc"
 	E2EWebhookServiceName      = "kubevirtbmc-webhook-service"
 	E2EWebhookServiceNamespace = "kubevirtbmc-system"
 	WebhookRegistrationDelay   = 10 * time.Second
 )
 
-func AgentPodKey(namespace string) types.NamespacedName {
-	return types.NamespacedName{Name: E2EAgentPodName, Namespace: namespace}
+func AgentDeploymentKey(namespace string) types.NamespacedName {
+	return types.NamespacedName{Name: E2EAgentDeploymentName, Namespace: namespace}
+}
+
+func AgentServiceKey(namespace string) types.NamespacedName {
+	return types.NamespacedName{Name: E2EAgentDeploymentName, Namespace: namespace}
 }
 
 func BMCKey(namespace string) types.NamespacedName {
@@ -53,35 +58,39 @@ func HasBMCCondition(ctx context.Context, k8sClient client.Client, namespace, co
 	}
 }
 
-func PodExists(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
+func DeploymentReady(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
 	return func() bool {
-		pod := &corev1.Pod{}
-		return k8sClient.Get(ctx, AgentPodKey(namespace), pod) == nil
+		deployment := &appsv1.Deployment{}
+		if err := k8sClient.Get(ctx, AgentDeploymentKey(namespace), deployment); err != nil {
+			return false
+		}
+
+		desiredReplicas := int32(1)
+		if deployment.Spec.Replicas != nil {
+			desiredReplicas = *deployment.Spec.Replicas
+		}
+
+		if deployment.Status.ObservedGeneration < deployment.Generation {
+			return false
+		}
+
+		return deployment.Status.UpdatedReplicas >= desiredReplicas &&
+			deployment.Status.ReadyReplicas >= desiredReplicas &&
+			deployment.Status.AvailableReplicas >= desiredReplicas
 	}
 }
 
-func PodNotFound(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
+func DeploymentExists(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
 	return func() bool {
-		pod := &corev1.Pod{}
-		return apierrors.IsNotFound(k8sClient.Get(ctx, AgentPodKey(namespace), pod))
+		deployment := &appsv1.Deployment{}
+		return k8sClient.Get(ctx, AgentDeploymentKey(namespace), deployment) == nil
 	}
 }
 
-func PodRunningAndReady(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
+func DeploymentNotFound(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
 	return func() bool {
-		pod := &corev1.Pod{}
-		if err := k8sClient.Get(ctx, AgentPodKey(namespace), pod); err != nil {
-			return false
-		}
-		if pod.Status.Phase != corev1.PodRunning {
-			return false
-		}
-		for _, cond := range pod.Status.Conditions {
-			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-				return true
-			}
-		}
-		return false
+		deployment := &appsv1.Deployment{}
+		return apierrors.IsNotFound(k8sClient.Get(ctx, AgentDeploymentKey(namespace), deployment))
 	}
 }
 
@@ -210,9 +219,9 @@ func EnsureTestVMSecretBMC(ctx context.Context, k8sClient client.Client, namespa
 		}
 	}
 
-	By("waiting for VMI to reach Running and agent pod to become ready")
+	By("waiting for VMI to reach Running and agent Deployment to become ready")
 	Eventually(VMIRunning(ctx, k8sClient, E2EVMName, namespace), timeout, interval).Should(BeTrue(), "VMI %s/%s should reach Running", namespace, E2EVMName)
-	Eventually(PodRunningAndReady(ctx, k8sClient, namespace), timeout, interval).Should(BeTrue(), "agent pod %s/%s should become ready", namespace, E2EAgentPodName)
+	Eventually(DeploymentReady(ctx, k8sClient, namespace), timeout, interval).Should(BeTrue(), "agent Deployment %s/%s should become ready", namespace, E2EAgentDeploymentName)
 	return nil
 }
 

--- a/test/virtbmc-agent/agent_helpers.go
+++ b/test/virtbmc-agent/agent_helpers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ const (
 	ipmitoolImage        = "mikeynap/ipmitool:latest"
 	agentTestTimeout     = 60 * time.Second
 	agentTestInterval    = 250 * time.Millisecond
-	agentPodName         = "testvm-virtbmc"
+	agentDeploymentName  = "testvm-virtbmc"
 	vmPowerStatusTimeout = 120 * time.Second
 	helperPodTimeout     = 180 * time.Second
 
@@ -77,7 +78,7 @@ func ensureAgentTestEnv(ctx context.Context, namespace string, k8sClient client.
 		return nil, err
 	}
 
-	waitForAgentPodReady(ctx, k8sClient, namespace, agentPodName)
+	waitForAgentDeploymentReady(ctx, k8sClient, namespace, agentDeploymentName)
 
 	return env, nil
 }
@@ -167,19 +168,26 @@ func (e *agentTestEnv) ensureBMCExists(ctx context.Context, k8sClient client.Cli
 	return k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: agentBMCName}, bmc)
 }
 
-func waitForAgentPodReady(ctx context.Context, k8sClient client.Client, namespace, podName string) {
+func waitForAgentDeploymentReady(ctx context.Context, k8sClient client.Client, namespace, deploymentName string) {
 	Eventually(func() bool {
-		var pod corev1.Pod
-		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: podName}, &pod); err != nil {
+		var deployment appsv1.Deployment
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: deploymentName}, &deployment); err != nil {
 			return false
 		}
-		for _, c := range pod.Status.Conditions {
-			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
-				return true
-			}
+
+		desiredReplicas := int32(1)
+		if deployment.Spec.Replicas != nil {
+			desiredReplicas = *deployment.Spec.Replicas
 		}
-		return false
-	}, agentTestTimeout, agentTestInterval).Should(BeTrue(), "agent pod %q should become ready", podName)
+
+		if deployment.Status.ObservedGeneration < deployment.Generation {
+			return false
+		}
+
+		return deployment.Status.UpdatedReplicas >= desiredReplicas &&
+			deployment.Status.ReadyReplicas >= desiredReplicas &&
+			deployment.Status.AvailableReplicas >= desiredReplicas
+	}, agentTestTimeout, agentTestInterval).Should(BeTrue(), "agent deployment %q should become ready", deploymentName)
 }
 
 func CreateRedfishClientPod(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {

--- a/test/virtbmc-controller/controller_test.go
+++ b/test/virtbmc-controller/controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +27,7 @@ const (
 )
 
 var (
-	serviceAccountName = util.E2EAgentPodName
+	serviceAccountName = util.E2EAgentDeploymentName
 	roleBindingName    = util.E2EVMName + "-virtbmc-rolebinding"
 )
 
@@ -134,17 +135,17 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			}, timeout, interval).Should(BeTrue(), "RoleBinding should be created")
 		})
 
-		It("should create a ready agent Pod", func() {
-			By("verifying the agent Pod exists")
-			Eventually(util.PodExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should be created")
-			By("verifying the agent Pod is Running")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+		It("should create an agent Deployment and mark it ready", func() {
+			By("verifying the agent Deployment exists")
+			Eventually(util.DeploymentExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should be created")
+			By("verifying the agent Deployment becomes ready")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 		})
 
 		It("should create an agent Service", func() {
 			Eventually(func() bool {
 				svc := &corev1.Service{}
-				return k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), svc) == nil
+				return k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), svc) == nil
 			}, timeout, interval).Should(BeTrue(), "agent Service should be created")
 		})
 
@@ -172,7 +173,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 
 	Context("when the VirtualMachine is deleted", func() {
 
-		It("should delete the agent Pod and set VirtualMachineAvailable=False", func() {
+		It("should delete the agent Deployment and set VirtualMachineAvailable=False", func() {
 			By("deleting the VirtualMachine")
 
 			vm := &kubevirtv1.VirtualMachine{}
@@ -187,9 +188,9 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			Eventually(util.VMNotFound(ctx, k8sClient, util.E2EVMName, util.E2ENamespace), vmDeletionTimeout, interval).Should(BeTrue(),
 				"VirtualMachine should be fully deleted")
 
-			By("verifying the agent Pod is removed")
-			Eventually(util.PodNotFound(ctx, k8sClient, util.E2ENamespace), vmDeletionTimeout, interval).Should(BeTrue(),
-				"agent Pod should be deleted when VM is gone")
+			By("verifying the agent Deployment is removed")
+			Eventually(util.DeploymentNotFound(ctx, k8sClient, util.E2ENamespace), vmDeletionTimeout, interval).Should(BeTrue(),
+				"agent Deployment should be deleted when VM is gone")
 
 			By("verifying VirtualMachineAvailable=False with reason VirtualMachineNotFound")
 			Eventually(
@@ -219,22 +220,23 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 				timeout, interval,
 			).Should(BeTrue())
 
-			By("verifying the agent Pod is re-created and running")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+			By("verifying the agent Deployment is re-created and becomes ready")
+			Eventually(util.DeploymentExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should be re-created")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 
 		})
 	})
 
 	Context("when the Secret is deleted", func() {
-		It("should delete the agent Pod and set SecretAvailable=False", func() {
+		It("should delete the agent Deployment and set SecretAvailable=False", func() {
 			By("deleting the Secret")
 			secret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: util.E2ESecretName, Namespace: util.E2ENamespace}, secret)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
 
-			By("verifying the agent Pod is removed")
-			Eventually(util.PodNotFound(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(),
-				"agent Pod should be deleted when Secret is gone")
+			By("verifying the agent Deployment is removed")
+			Eventually(util.DeploymentNotFound(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(),
+				"agent Deployment should be deleted when Secret is gone")
 
 			By("verifying SecretAvailable=False with reason SecretNotFound")
 			Eventually(
@@ -253,19 +255,23 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 				timeout, interval,
 			).Should(BeTrue())
 
-			By("verifying the agent Pod is re-created and running")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+			By("verifying the agent Deployment is re-created and becomes ready")
+			Eventually(util.DeploymentExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should be re-created")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 		})
 	})
 
 	Context("when the Secret is modified", func() {
-		It("should delete the agent Pod and let the controller recreate it", func() {
+		It("should rollout restart the agent Deployment", func() {
 			By("verifying the agent Pod is running before the change")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 
-			var podBefore corev1.Pod
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &podBefore)).To(Succeed())
-			originalUID := podBefore.UID
+			var deploymentBefore appsv1.Deployment
+			Expect(k8sClient.Get(ctx, util.AgentDeploymentKey(util.E2ENamespace), &deploymentBefore)).To(Succeed())
+			originalRestartedAt := ""
+			if deploymentBefore.Spec.Template.Annotations != nil {
+				originalRestartedAt = deploymentBefore.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+			}
 
 			By("modifying the Secret")
 			secret := &corev1.Secret{}
@@ -273,17 +279,21 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			secret.Data["password"] = []byte("new-password")
 			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
 
-			By("verifying the controller reacted: pod is removed and/or recreated with new UID")
+			By("verifying the controller reacted by updating the Deployment restart annotation")
 			Eventually(func() bool {
-				var pod corev1.Pod
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &pod); err != nil {
-					return errors.IsNotFound(err)
+				var deployment appsv1.Deployment
+				if err := k8sClient.Get(ctx, util.AgentDeploymentKey(util.E2ENamespace), &deployment); err != nil {
+					return false
 				}
-				return pod.UID != originalUID
-			}, timeout, interval).Should(BeTrue(), "agent Pod should be deleted or recreated when Secret is modified")
+				if deployment.Spec.Template.Annotations == nil {
+					return false
+				}
+				restartedAt := deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+				return restartedAt != "" && restartedAt != originalRestartedAt
+			}, timeout, interval).Should(BeTrue(), "agent Deployment should get a rollout restart annotation when Secret is modified")
 
 			By("verifying the agent Pod is running after controller reconciles")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 		})
 	})
 })


### PR DESCRIPTION
Tracking issue: #162 

- Changed the pod with deployment
- Refractor the controller test 
- Refractor the E2E. 

> [!NOTE]
> As a part this PR the default value of the bmc deployment replica is set to 1. User are not allow to set the replicas to 2 . We need to introduce the new field in the CRD. I will create the sub task for it in issue 136
