### PR TITLE
fix: add 10% storage overhead to DataVolume to account for CDI filesystem overhead

### DIFF
--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -22,6 +22,10 @@ const (
 	defaultManagerName      = "Manager"
 	defaultVirtualMediaId   = "CD1"
 	defaultVirtualMediaName = "Virtual Media"
+
+	// dataVolumeStorageOverhead adds 15% to the requested storage size to account for
+	// CDI filesystem overhead in the scratch PVC used during import.
+	dataVolumeStorageOverhead = 0.10
 )
 
 var (
@@ -200,7 +204,7 @@ func (m *VirtualMachineResourceManager) InsertMedia(imageURL string) error {
 	}
 
 	// Create DataVolume
-	dv := util.ConstructDataVolume(m.namespace, m.name, imageURL, imageSize)
+	dv := util.ConstructDataVolume(m.namespace, m.name, imageURL, util.StorageWithOverhead(imageSize, dataVolumeStorageOverhead))
 	_, err = m.cdiClient.CdiV1beta1().DataVolumes(m.namespace).Create(m.ctx, dv, metav1.CreateOptions{})
 	if err != nil {
 		return err

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -25,6 +25,8 @@ const (
 	testImageSizeBytes = int64(1 << 30) // 1 GiB = 1073741824
 )
 
+var testImageSizePadded = util.StorageWithOverhead(testImageSizeBytes, dataVolumeStorageOverhead)
+
 type fakeVirtualMedia struct {
 	called   bool
 	imageURL string
@@ -254,7 +256,7 @@ func TestVirtualMachineResourceManager_InsertMedia(t *testing.T) {
 			},
 			expectedDV: builder.NewDataVolumeBuilder(testNamespace, testVMName).
 				WithHTTPSource(imageURL).
-				WithStorage(testImageSizeBytes).Build(),
+				WithStorage(testImageSizePadded).Build(),
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				WithTemplate().
 				WithCDRomDisk("cdrom", nil).
@@ -313,7 +315,7 @@ func TestVirtualMachineResourceManager_InsertMedia(t *testing.T) {
 			},
 			expectedDV: builder.NewDataVolumeBuilder(testNamespace, testVMName).
 				WithHTTPSource(imageURL).
-				WithStorage(testImageSizeBytes).Build(),
+				WithStorage(testImageSizePadded).Build(),
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				WithTemplate().
 				WithCDRomDisk("cdrom", nil).

--- a/pkg/util/helper.go
+++ b/pkg/util/helper.go
@@ -72,6 +72,10 @@ func ConstructDataVolume(namespace, name, url string, size int64) *cdiv1.DataVol
 	}
 }
 
+func StorageWithOverhead(size int64, overheadFactor float64) int64 {
+	return size + int64(float64(size)*overheadFactor)
+}
+
 func GetCdromDisk(disks []kubevirtv1.Disk) (*kubevirtv1.Disk, error) {
 	for i := range disks {
 		if disks[i].CDRom != nil {


### PR DESCRIPTION
Tracking issue: #131 


When attaching virtual media, the DataVolume was created with storage exactly equal to the image size. CDI's scratch PVC has filesystem overhead (nearly 5-10%) which reduces usable space below the image size, causing the import to fail.

Adding 10% padding to the storage request, which covers CDI's default 6% overhead with a safe buffer.


Testing: 

Before: 


```yaml

  capacity:
    storage: "3502306755"
  phase: Bound
```


After adding `0.10` overhead


```yaml

status:
  capacity:
    storage: "3852426281"
  phase: Bound
```
