### PR TITLE
Fix: advertise Manager.Reset action on /redfish/v1/Managers/BMC

### DIFF
--- a/pkg/redfish/api_service.go
+++ b/pkg/redfish/api_service.go
@@ -30556,25 +30556,7 @@ func (s *APIService) RedfishV1ManagersManagerIdActionsManagerModifyRedundancySet
 
 // RedfishV1ManagersManagerIdActionsManagerResetPost -
 func (s *APIService) RedfishV1ManagersManagerIdActionsManagerResetPost(ctx context.Context, managerId string, managerV1190ResetRequestBody server.ManagerV1190ResetRequestBody) (server.ImplResponse, error) {
-	// TODO - update RedfishV1ManagersManagerIdActionsManagerResetPost with the required logic for this service method.
-	// Add api_default_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, RedfishError{}) or use other options such as http.Ok ...
-	// return Response(200, RedfishError{}), nil
-
-	// TODO: Uncomment the next line to return response Response(201, RedfishError{}) or use other options such as http.Ok ...
-	// return Response(201, RedfishError{}), nil
-
-	// TODO: Uncomment the next line to return response Response(202, TaskV173Task{}) or use other options such as http.Ok ...
-	// return Response(202, TaskV173Task{}), nil
-
-	// TODO: Uncomment the next line to return response Response(204, {}) or use other options such as http.Ok ...
-	// return Response(204, nil),nil
-
-	// TODO: Uncomment the next line to return response Response(0, RedfishError{}) or use other options such as http.Ok ...
-	// return Response(0, RedfishError{}), nil
-
-	return server.Response(http.StatusNotImplemented, nil), errors.New("RedfishV1ManagersManagerIdActionsManagerResetPost method not implemented")
+	return server.Response(http.StatusNoContent, nil), nil
 }
 
 // RedfishV1ManagersManagerIdActionsManagerResetToDefaultsPost -

--- a/pkg/resourcemanager/manager_resource.go
+++ b/pkg/resourcemanager/manager_resource.go
@@ -31,8 +31,13 @@ func NewManager(id, name string) *ManagerAdapter {
 		Status:       server.ResourceStatus{},
 		ManagerType:  "BMC",
 		Links:        server.ManagerV1190Links{},
-		Actions:      server.ManagerV1190Actions{},
-		DateTime:     util.Ptr(time.Now()),
+		Actions: server.ManagerV1190Actions{
+			ManagerReset: server.ManagerV1190Reset{
+				Target: fmt.Sprintf("/redfish/v1/Managers/%s/Actions/Manager.Reset", id),
+				Title:  "Reset",
+			},
+		},
+		DateTime: util.Ptr(time.Now()),
 		EthernetInterfaces: server.OdataV4IdRef{
 			OdataId: fmt.Sprintf("/redfish/v1/Managers/%s/EthernetInterfaces", id),
 		},


### PR DESCRIPTION
Tracking issue: #156 

Testing: 

Output of below command: 

```yaml
curl -H "X-Auth-Token: $TOKEN" \
   http://testvm-virtbmc.default.svc.cluster.local/redfish/v1/Managers/BMC | jq 

````

```yaml

{
  "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
  "@odata.id": "/redfish/v1/Managers/BMC",
  "@odata.type": "#Manager.v1_19_2.Manager",
  "Actions": {
    "#Manager.ForceFailover": {},
    "#Manager.ModifyRedundancySet": {},
    "#Manager.Reset": {
      "target": "/redfish/v1/Managers/BMC/Actions/Manager.Reset", # Getting the correct reponse
      "title": "Reset"
    },
    "#Manager.ResetToDefaults": {}
  },
  "AdditionalFirmwareVersions": {},
  "Certificates": {},
  "CommandShell": {},
  "DateTime": "2026-04-28T02:29:59.588758541Z",
  "DaylightSavingTime": {
    "EndDateTime": "0001-01-01T00:00:00Z",
    "StartDateTime": "0001-01-01T00:00:00Z"
  },
  "DedicatedNetworkPorts": {},
  "Description": "Manager",
  "EthernetInterfaces": {
    "@odata.id": "/redfish/v1/Managers/BMC/EthernetInterfaces"
  },
  "GraphicalConsole": {},
  "HostInterfaces": {},
  "Id": "BMC",
  "LastResetTime": "0001-01-01T00:00:00Z",
  "Links": {
    "ActiveSoftwareImage": {},
    "ManagerForServers": [
      {
        "@odata.id": "/redfish/v1/Systems/1"
      }
    ],
    "ManagerInChassis": {},
    "SelectedNetworkPort": {}
  },
  "Location": {
    "PartLocation": {},
    "PhysicalAddress": {},
    "Placement": {},
    "PostalAddress": {}
  },
  "LogServices": {
    "@odata.id": "/redfish/v1/Managers/BMC/LogServices"
  },
  "ManagerDiagnosticData": {},
  "ManagerType": "BMC",
  "Model": "KubeVirtBMC",
  "Name": "Manager",
  "NetworkProtocol": {},
  "RemoteAccountService": {},
  "SecurityPolicy": {},
  "SerialConsole": {},
  "SerialInterfaces": {
    "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces"
  },
  "SharedNetworkPorts": {},
  "Status": {},
  "USBPorts": {},
  "UUID": "00000000-0000-0000-0000-000000000000",
  "VirtualMedia": {
    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia"
  }
}

````