### PR TITLE
Fix: populate VirtualMedia Actions with EjectMedia and InsertMedia target URLs

### DIFF
--- a/pkg/resourcemanager/virtualmedia_resource.go
+++ b/pkg/resourcemanager/virtualmedia_resource.go
@@ -19,10 +19,21 @@ type VirtualMediaAdapter struct {
 }
 
 func NewVirtualMedia(id, name string) *VirtualMediaAdapter {
+	odataId := fmt.Sprintf("/redfish/v1/Managers/BMC/VirtualMedia/%s", id)
 	generatedVirtualMedia := &server.VirtualMediaV163VirtualMedia{
 		OdataContext: "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
-		OdataId:      fmt.Sprintf("/redfish/v1/Managers/BMC/VirtualMedia/%s", id),
+		OdataId:      odataId,
 		OdataType:    "#VirtualMedia.v1_6_3.VirtualMedia",
+		Actions: server.VirtualMediaV163Actions{
+			VirtualMediaEjectMedia: server.VirtualMediaV163EjectMedia{
+				Target: fmt.Sprintf("%s/Actions/VirtualMedia.EjectMedia", odataId),
+				Title:  "EjectMedia",
+			},
+			VirtualMediaInsertMedia: server.VirtualMediaV163InsertMedia{
+				Target: fmt.Sprintf("%s/Actions/VirtualMedia.InsertMedia", odataId),
+				Title:  "InsertMedia",
+			},
+		},
 		ConnectedVia: server.VIRTUALMEDIAV163CONNECTEDVIA_NOT_CONNECTED,
 		Description:  "Virtual Media",
 		Name:         name,


### PR DESCRIPTION
Tracking Issue: #172 

Before fix: 

```yaml
{
  "@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
  "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/CD1",
  "@odata.type": "#VirtualMedia.v1_6_3.VirtualMedia",
  "Actions": {
    "#VirtualMedia.EjectMedia": {}, #  Field were empty
    "#VirtualMedia.InsertMedia": {}
  },
  "Certificates": {},
  "ClientCertificates": {},
  "ConnectedVia": "URI",
  "Description": "Virtual Media",
  "Id": "CD1",
  "Image": "https://releases.ubuntu.com/noble/ubuntu-24.04.3-live-server-amd64.iso",
  "ImageName": "",
  "Inserted": true,
  "MediaTypes": [
    "CD",
    "DVD"
  ],
  "Name": "Virtual Media",
  "Status": {},
  "WriteProtected": false
}
```


After fix: 

```yaml
{
  "@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
  "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/CD1",
  "@odata.type": "#VirtualMedia.v1_6_3.VirtualMedia",
  "Actions": {
    "#VirtualMedia.EjectMedia": {
      "target": "/redfish/v1/Managers/BMC/VirtualMedia/CD1/Actions/VirtualMedia.EjectMedia",
      "title": "EjectMedia"
    },
    "#VirtualMedia.InsertMedia": {
      "target": "/redfish/v1/Managers/BMC/VirtualMedia/CD1/Actions/VirtualMedia.InsertMedia",
      "title": "InsertMedia"
    }
  },
   "Certificates": {},
  "ClientCertificates": {},
  "ConnectedVia": "URI",
  "Description": "Virtual Media",
  "Id": "CD1",
  "Image": "https://releases.ubuntu.com/noble/ubuntu-24.04.3-live-server-amd64.iso",
  "ImageName": "",
  "Inserted": true,
  "MediaTypes": [
    "CD",
    "DVD"
  ],
  "Name": "Virtual Media",
  "Status": {},
  "WriteProtected": false
}
```