### PR TITLE
Fix: handle InsertMedia retry by deleting stale DataVolume and skipping duplicate volume attachment

### DIFF
--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -204,6 +204,11 @@ func (m *VirtualMachineResourceManager) InsertMedia(imageURL string) error {
 		return err
 	}
 
+	// Delete existing DataVolume if present.
+	if err := m.cdiClient.CdiV1beta1().DataVolumes(m.namespace).Delete(m.ctx, m.name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
 	// Create DataVolume
 	dv := util.ConstructDataVolume(m.namespace, m.name, imageURL, imageSize)
 	_, err = m.cdiClient.CdiV1beta1().DataVolumes(m.namespace).Create(m.ctx, dv, metav1.CreateOptions{})
@@ -211,17 +216,20 @@ func (m *VirtualMachineResourceManager) InsertMedia(imageURL string) error {
 		return err
 	}
 
-	// Attach DataVolume to VirtualMachine
-	volume := kubevirtv1.Volume{
-		Name: cdromDisk.Name,
-		VolumeSource: kubevirtv1.VolumeSource{
-			DataVolume: &kubevirtv1.DataVolumeSource{
-				Name:         dv.Name,
-				Hotpluggable: true,
+	// Attach DataVolume to VirtualMachine only if not already attached.
+	if !slices.ContainsFunc(vm.Spec.Template.Spec.Volumes, func(v kubevirtv1.Volume) bool {
+		return v.Name == cdromDisk.Name
+	}) {
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, kubevirtv1.Volume{
+			Name: cdromDisk.Name,
+			VolumeSource: kubevirtv1.VolumeSource{
+				DataVolume: &kubevirtv1.DataVolumeSource{
+					Name:         dv.Name,
+					Hotpluggable: true,
+				},
 			},
-		},
+		})
 	}
-	vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, volume)
 
 	if _, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
 		Update(m.ctx, vm, metav1.UpdateOptions{}); err != nil {

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -373,7 +373,7 @@ func TestVirtualMachineResourceManager_InsertMedia(t *testing.T) {
 			shouldError: false,
 		},
 		{
-			name:         "Insert media into a virtual machine who already has media inserted should fail",
+			name:         "Insert media retry when DataVolume already exists and already attached should succeed without duplicate volumes",
 			imageURL:     imageURL,
 			virtualMedia: &fakeVirtualMedia{},
 			dv: builder.NewDataVolumeBuilder(testNamespace, testVMName).
@@ -391,9 +391,15 @@ func TestVirtualMachineResourceManager_InsertMedia(t *testing.T) {
 						},
 					},
 				}).Build(),
+			expectedVirtualMedia: &fakeVirtualMedia{
+				called:   true,
+				imageURL: imageURL,
+				inserted: true,
+			},
 			expectedDV: builder.NewDataVolumeBuilder(testNamespace, testVMName).
 				WithHTTPSource(imageURL).
-				WithStorage(testImageSizeBytes).Build(),
+				WithStorage(testImageSizeBytes).
+				WithAnnotation("cdi.kubevirt.io/storage.bind.immediate.requested", "").Build(),
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				WithTemplate().
 				WithCDRomDisk("cdrom", nil).
@@ -406,7 +412,40 @@ func TestVirtualMachineResourceManager_InsertMedia(t *testing.T) {
 						},
 					},
 				}).Build(),
-			shouldError: true,
+			shouldError: false,
+		},
+		{
+			name:         "Insert media retry when DataVolume already exists but not yet attached should succeed",
+			imageURL:     imageURL,
+			virtualMedia: &fakeVirtualMedia{},
+			dv: builder.NewDataVolumeBuilder(testNamespace, testVMName).
+				WithHTTPSource(imageURL).
+				WithStorage(testImageSizeBytes).Build(),
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithTemplate().
+				WithCDRomDisk("cdrom", nil).Build(),
+			expectedVirtualMedia: &fakeVirtualMedia{
+				called:   true,
+				imageURL: imageURL,
+				inserted: true,
+			},
+			expectedDV: builder.NewDataVolumeBuilder(testNamespace, testVMName).
+				WithHTTPSource(imageURL).
+				WithStorage(testImageSizeBytes).
+				WithAnnotation("cdi.kubevirt.io/storage.bind.immediate.requested", "").Build(),
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithTemplate().
+				WithCDRomDisk("cdrom", nil).
+				WithVolumes(kubevirtv1.Volume{
+					Name: "cdrom",
+					VolumeSource: kubevirtv1.VolumeSource{
+						DataVolume: &kubevirtv1.DataVolumeSource{
+							Name:         testVMName,
+							Hotpluggable: true,
+						},
+					},
+				}).Build(),
+			shouldError: false,
 		},
 	}
 


### PR DESCRIPTION
Tracking issue: #174, #177 

This PR fixes two related issues in InsertMedia that caused failures on retry.                                                                                                                                    
                                                                                                                                                                                                                    
  Previously, if InsertMedia was called again without an EjectMedia in between, it would fail either because the old DataVolume still existed from the previous attempt, or because the admission webhook rejected  
  the update due to duplicate volume entries in the VM spec.                                                                                                                                                        
                                                                                                                                                                                                                    
The fix deletes any pre-existing DataVolume before creating a new one, and skips appending the cdrom volume if it is already attached to the VM.    