### PR TITLE
  Fix: tolerate empty body in EjectMedia handler for VirtualMedia

### DIFF
--- a/pkg/generated/redfish/server/api_default.go
+++ b/pkg/generated/redfish/server/api_default.go
@@ -13,6 +13,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -83416,7 +83417,13 @@ func (c *DefaultAPIController) RedfishV1ManagersManagerIdVirtualMediaVirtualMedi
 	bodyParam := map[string]interface{}{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&bodyParam); err != nil {
+	// EjectMedia takes no required parameters. Per the Redfish spec, clients
+	// without any parameters should send an empty JSON object ("{}"), but some
+	// client implementations (e.g. older versions of sushy used by Ironic/Metal3)
+	// send a completely empty body instead. Treat io.EOF from an empty body as
+	// "no parameters supplied" rather than a parsing error, for the convenience
+	// of these client implementations.
+	if err := d.Decode(&bodyParam); err != nil && err != io.EOF {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}


### PR DESCRIPTION
Tracking issue: #173 


## Before Fix: 


<img width="1856" height="832" alt="Screenshot From 2026-05-02 11-26-42" src="https://github.com/user-attachments/assets/8028e6ae-aa2a-4c5b-865a-fef5e643fad9" />



## After fix: 

<img width="1412" height="992" alt="Screenshot From 2026-05-02 11-20-47" src="https://github.com/user-attachments/assets/4561f8f0-cceb-4cb9-8230-7ef4e751885f" />


