### PR TITLE
feat: Support CD-ROM Boot Order

### DIFF
--- a/pkg/ipmi/handler.go
+++ b/pkg/ipmi/handler.go
@@ -91,6 +91,9 @@ func (h *handler) setSystemBootOptionsHandler(m *goipmi.Message) goipmi.Response
 	case uint8(goipmi.BootDeviceDisk):
 		logrus.Infof("set bootdev disk")
 		device = resourcemanager.BootDeviceHdd
+	case uint8(goipmi.BootDeviceCdrom):
+		logrus.Infof("set bootdev cdrom")
+		device = resourcemanager.BootDeviceCd
 	}
 
 	err := h.rm.SetBootDevice(device)

--- a/pkg/ipmi/handler_test.go
+++ b/pkg/ipmi/handler_test.go
@@ -192,6 +192,22 @@ func TestSetSystemBootOptionsHandler(t *testing.T) {
 			},
 			expectedCode: goipmi.ErrUnspecified,
 		},
+		{
+			name:       "SetSystemBootOptions with cdrom success",
+			bootDevice: goipmi.BootDeviceCdrom,
+			expectedCall: func() {
+				mockRM.EXPECT().SetBootDevice(gomock.Any()).Return(nil)
+			},
+			expectedCode: goipmi.CommandCompleted,
+		},
+		{
+			name:       "SetSystemBootOptions with cdrom failed",
+			bootDevice: goipmi.BootDeviceCdrom,
+			expectedCall: func() {
+				mockRM.EXPECT().SetBootDevice(gomock.Any()).Return(fmt.Errorf("error"))
+			},
+			expectedCode: goipmi.ErrUnspecified,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/redfish/handler.go
+++ b/pkg/redfish/handler.go
@@ -217,6 +217,8 @@ func (h *handler) PatchComputerSystem(computerSystemPatch *server.ComputerSystem
 			bootDevice = resourcemanager.BootDevicePxe
 		case server.COMPUTERSYSTEMBOOTSOURCE_HDD:
 			bootDevice = resourcemanager.BootDeviceHdd
+		case server.COMPUTERSYSTEMBOOTSOURCE_CD:
+			bootDevice = resourcemanager.BootDeviceCd
 		default:
 			return nil
 		}

--- a/pkg/redfish/handler_test.go
+++ b/pkg/redfish/handler_test.go
@@ -237,6 +237,39 @@ func TestPatchComputerSystem(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "valid boot source override target to Cd (once)",
+			boot: server.ComputerSystemV1220Boot{
+				BootSourceOverrideEnabled: server.COMPUTERSYSTEMV1220BOOTSOURCEOVERRIDEENABLED_ONCE,
+				BootSourceOverrideTarget:  server.COMPUTERSYSTEMBOOTSOURCE_CD,
+			},
+			mockSetup: func() {
+				mockRM.EXPECT().SetBootDevice(resourcemanager.BootDeviceCd).Return(nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "valid boot source override target to Cd (continuous)",
+			boot: server.ComputerSystemV1220Boot{
+				BootSourceOverrideEnabled: server.COMPUTERSYSTEMV1220BOOTSOURCEOVERRIDEENABLED_CONTINUOUS,
+				BootSourceOverrideTarget:  server.COMPUTERSYSTEMBOOTSOURCE_CD,
+			},
+			mockSetup: func() {
+				mockRM.EXPECT().SetBootDevice(resourcemanager.BootDeviceCd).Return(nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "failed to set Cd boot device",
+			boot: server.ComputerSystemV1220Boot{
+				BootSourceOverrideEnabled: server.COMPUTERSYSTEMV1220BOOTSOURCEOVERRIDEENABLED_ONCE,
+				BootSourceOverrideTarget:  server.COMPUTERSYSTEMBOOTSOURCE_CD,
+			},
+			mockSetup: func() {
+				mockRM.EXPECT().SetBootDevice(resourcemanager.BootDeviceCd).Return(assert.AnError)
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/resourcemanager/resourcemanager.go
+++ b/pkg/resourcemanager/resourcemanager.go
@@ -5,6 +5,7 @@ type BootDevice string
 const (
 	BootDevicePxe BootDevice = "Pxe"
 	BootDeviceHdd BootDevice = "Hdd"
+	BootDeviceCd  BootDevice = "Cd"
 )
 
 type ResourceManager interface {

--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -32,6 +32,7 @@ var (
 	bootSourceMap = map[BootDevice]server.ComputerSystemBootSource{
 		BootDevicePxe: server.COMPUTERSYSTEMBOOTSOURCE_PXE,
 		BootDeviceHdd: server.COMPUTERSYSTEMBOOTSOURCE_HDD,
+		BootDeviceCd:  server.COMPUTERSYSTEMBOOTSOURCE_CD,
 	}
 )
 
@@ -342,6 +343,18 @@ func (m *VirtualMachineResourceManager) SetBootDevice(bootDevice BootDevice) err
 		}
 		vm.Spec.Template.Spec.Domain.Devices.Disks[0].BootOrder = &firstOrder
 		logrus.Infof("To be updated vm: %+v", vm.Spec.Template.Spec.Domain.Devices.Disks[0])
+	case BootDeviceCd:
+		cdromDisk, err := util.GetCdromDisk(vm.Spec.Template.Spec.Domain.Devices.Disks)
+		if err != nil {
+			return fmt.Errorf("no cdrom found: %w", err)
+		}
+		for i, disk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+			if disk.Name == cdromDisk.Name {
+				vm.Spec.Template.Spec.Domain.Devices.Disks[i].BootOrder = &firstOrder
+				logrus.Infof("To be updated vm: %+v", vm.Spec.Template.Spec.Domain.Devices.Disks[i])
+				break
+			}
+		}
 	}
 
 	if _, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -906,6 +906,65 @@ func TestVirtualMachineResourceManager_SetBootDevice(t *testing.T) {
 		// 		AddInterface("test-interface", util.Ptr[uint](1)).Build(),
 		// 	shouldError: false,
 		// },
+		{
+			name: "Set boot device to Cd for a virtual machine with single cdrom should succeed",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithCDRomDisk("test-cdrom", nil).Build(),
+			bootDevice: BootDeviceCd,
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithCDRomDisk("test-cdrom", util.Ptr[uint](1)).Build(),
+			shouldError: false,
+		},
+		{
+			name: "Set boot device to Cd for a virtual machine with disk and cdrom should succeed",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithDisk("test-disk", nil).
+				WithCDRomDisk("test-cdrom", nil).Build(),
+			bootDevice: BootDeviceCd,
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithDisk("test-disk", nil).
+				WithCDRomDisk("test-cdrom", util.Ptr[uint](1)).Build(),
+			shouldError: false,
+		},
+		{
+			name: "Set boot device to Cd for a virtual machine with disk, interface and cdrom should succeed and clear other boot orders",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithDisk("test-disk", util.Ptr[uint](1)).
+				WithInterface("test-interface", nil).
+				WithCDRomDisk("test-cdrom", nil).Build(),
+			bootDevice: BootDeviceCd,
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithDisk("test-disk", nil).
+				WithInterface("test-interface", nil).
+				WithCDRomDisk("test-cdrom", util.Ptr[uint](1)).Build(),
+			shouldError: false,
+		},
+		{
+			name: "Set boot device to Cd for a virtual machine with no cdrom should fail",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithDisk("test-disk", nil).Build(),
+			bootDevice:  BootDeviceCd,
+			shouldError: true,
+		},
+		{
+			name: "Set boot device to Cd for a virtual machine with no disks should fail",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
+			bootDevice:  BootDeviceCd,
+			shouldError: true,
+		},
+		{
+			name: "Set boot device to Cd for a virtual machine with disk, interface and cdrom with existing boot order should succeed",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithDisk("test-disk", nil).
+				WithInterface("test-interface", util.Ptr[uint](1)).
+				WithCDRomDisk("test-cdrom", nil).Build(),
+			bootDevice: BootDeviceCd,
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithDisk("test-disk", nil).
+				WithInterface("test-interface", nil).
+				WithCDRomDisk("test-cdrom", util.Ptr[uint](1)).Build(),
+			shouldError: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -947,7 +947,7 @@ func TestVirtualMachineResourceManager_SetBootDevice(t *testing.T) {
 			shouldError: true,
 		},
 		{
-			name: "Set boot device to Cd for a virtual machine with no disks should fail",
+			name:        "Set boot device to Cd for a virtual machine with no disks should fail",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
 			bootDevice:  BootDeviceCd,
 			shouldError: true,

--- a/test/virtbmc-agent/agent_test.go
+++ b/test/virtbmc-agent/agent_test.go
@@ -116,6 +116,16 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					Equal(""),
 				))
 			})
+
+			It("should set boot device to cdrom", func() {
+				out, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(SatisfyAny(
+					ContainSubstring("Set Boot Device"),
+					ContainSubstring("Boot"),
+					Equal(""),
+				))
+			})
 		})
 	})
 

--- a/test/virtbmc-agent/agent_test.go
+++ b/test/virtbmc-agent/agent_test.go
@@ -222,6 +222,16 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				))
 			})
 
+			It("should set boot to Cd", func() {
+				body := `{"Boot":{"BootSourceOverrideTarget":"Cd","BootSourceOverrideEnabled":"Once"}}`
+				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.TrimSpace(out)).To(SatisfyAny(
+					ContainSubstring("200"),
+					ContainSubstring("204"),
+				))
+			})
+
 			It("should set boot mode to UEFI", func() {
 				body := `{"Boot":{"BootSourceOverrideMode":"UEFI"}}`
 				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))


### PR DESCRIPTION
Tracking issue: #168 

Once, ISO image download is completed we set the cdrom as boot device

```
curl -i \
  -X PATCH \
  -H "Content-Type: application/json" \
  -H "X-Auth-Token: $TOKEN" \
  http://testvm-virtbmc.default.svc.cluster.local/redfish/v1/Systems/1 \
  -d '{
    "Boot": {
      "BootSourceOverrideTarget": "Cd",
      "BootSourceOverrideEnabled": "Once"
    }
  }'
  ```
  
  Then after that we will restart the VM and after running `virtctl vnc testvm` output will be 
  
  
<img width="2395" height="912" alt="Screenshot From 2026-05-22 13-01-17" src="https://github.com/user-attachments/assets/4900e59d-6832-4338-91c7-48e6ec37a870" />

  