### PR TITLE
fix: add  annotation to DataVolume for WaitForFirstConsumer support

### DIFF
--- a/pkg/builder/datavolume.go
+++ b/pkg/builder/datavolume.go
@@ -22,6 +22,14 @@ func NewDataVolumeBuilder(namespace, name string) *DataVolumeBuilder {
 	}
 }
 
+func (b *DataVolumeBuilder) WithAnnotation(key, value string) *DataVolumeBuilder {
+	if b.dv.Annotations == nil {
+		b.dv.Annotations = map[string]string{}
+	}
+	b.dv.Annotations[key] = value
+	return b
+}
+
 func (b *DataVolumeBuilder) Build() *cdiv1.DataVolume {
 	return b.dv
 }

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -295,7 +295,8 @@ func TestVirtualMachineResourceManager_InsertMedia(t *testing.T) {
 			},
 			expectedDV: builder.NewDataVolumeBuilder(testNamespace, testVMName).
 				WithHTTPSource(imageURL).
-				WithStorage(testImageSizeBytes).Build(),
+				WithStorage(testImageSizeBytes).
+				WithAnnotation("cdi.kubevirt.io/storage.bind.immediate.requested", "").Build(),
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				WithTemplate().
 				WithCDRomDisk("cdrom", nil).
@@ -354,7 +355,8 @@ func TestVirtualMachineResourceManager_InsertMedia(t *testing.T) {
 			},
 			expectedDV: builder.NewDataVolumeBuilder(testNamespace, testVMName).
 				WithHTTPSource(imageURL).
-				WithStorage(testImageSizeBytes).Build(),
+				WithStorage(testImageSizeBytes).
+				WithAnnotation("cdi.kubevirt.io/storage.bind.immediate.requested", "").Build(),
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				WithTemplate().
 				WithCDRomDisk("cdrom", nil).

--- a/pkg/util/helper.go
+++ b/pkg/util/helper.go
@@ -13,6 +13,10 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
+// AnnStorageBindImmediateRequested is the DataVolume annotation that requests
+// immediate binding of the underlying PVC, bypassing WaitForFirstConsumer.
+const AnnStorageBindImmediateRequested = "cdi.kubevirt.io/storage.bind.immediate.requested"
+
 func Ptr[T any](value T) *T {
 	return &value
 }
@@ -54,6 +58,9 @@ func ConstructDataVolume(namespace, name, url string, size int64) *cdiv1.DataVol
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
+			Annotations: map[string]string{
+				AnnStorageBindImmediateRequested: "",
+			},
 		},
 		Spec: cdiv1.DataVolumeSpec{
 			Source: &cdiv1.DataVolumeSource{


### PR DESCRIPTION
Tracking issue: #175 

### Before
 - If the StorageClass had volumeBindingMode: WaitForFirstConsumer, the PVC remained Pending on a stopped VM (no consumer to trigger binding), so the ISO download never started.
 
### After: 
- The annotation cdi.kubevirt.io/storage.bind.immediate.requested is set on the DataVolume, telling CDI to bind the PVC immediately regardless of WaitForFirstConsumer. The importer pod runs and downloads the ISO even on a stopped VM.

