### PR TITLE
feat: Use KubeVirt subresource APIs for power operations

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,14 +73,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - subresources.kubevirt.io
-  resources:
-  - virtualmachines/start
-  - virtualmachines/stop
-  - virtualmachines/restart
-  verbs:
-  - update
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachines/start
+  - virtualmachines/stop
+  - virtualmachines/restart
+  verbs:
+  - update
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles

--- a/config/virtbmc/role.yaml
+++ b/config/virtbmc/role.yaml
@@ -23,6 +23,8 @@ rules:
 - apiGroups:
   - subresources.kubevirt.io
   resources:
+  - virtualmachines/start
+  - virtualmachines/stop
   - virtualmachines/restart
   verbs:
   - update

--- a/deploy/charts/kubevirtbmc/templates/rbac.yaml
+++ b/deploy/charts/kubevirtbmc/templates/rbac.yaml
@@ -202,6 +202,8 @@ rules:
 - apiGroups:
   - subresources.kubevirt.io
   resources:
+  - virtualmachines/start
+  - virtualmachines/stop
   - virtualmachines/restart
   verbs:
   - update

--- a/internal/controller/virtualmachinebmc/controller.go
+++ b/internal/controller/virtualmachinebmc/controller.go
@@ -212,6 +212,16 @@ func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualM
 							},
 						},
 					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/redfish/v1",
+								Port: intstr.FromString(redfishPortName),
+							},
+						},
+						InitialDelaySeconds: 2,
+						PeriodSeconds:       10,
+					},
 				},
 			},
 		},

--- a/pkg/ipmi/handler.go
+++ b/pkg/ipmi/handler.go
@@ -38,6 +38,7 @@ func (h *handler) chassisControlHandler(m *goipmi.Message) goipmi.Response {
 	}
 
 	if err != nil {
+		logrus.WithError(err).Error("chassis control failed")
 		return &goipmi.ChassisControlResponse{
 			CompletionCode: goipmi.ErrInvalidState,
 		}
@@ -53,6 +54,7 @@ func (h *handler) chassisStatusHandler(*goipmi.Message) goipmi.Response {
 
 	isUp, err := h.rm.GetPowerStatus()
 	if err != nil {
+		logrus.WithError(err).Error("get power status failed")
 		return &goipmi.ChassisStatusResponse{
 			CompletionCode: goipmi.ErrInvalidState,
 		}

--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiclient "kubevirt.io/client-go/containerizeddataimporter"
@@ -252,31 +253,44 @@ func (m *VirtualMachineResourceManager) GetPowerStatus() (bool, error) {
 }
 
 func (m *VirtualMachineResourceManager) PowerOn() error {
-	err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
-		Start(m.ctx, m.name, &kubevirtv1.StartOptions{})
+	exists, err := m.isVMIExists()
 	if err != nil {
-		// The VM is already running — the operation succeeded.
-		if strings.Contains(err.Error(), "already running") {
-			logrus.WithError(err).Info("VM is already running")
-			return nil
-		}
-		return err
+		return err // propagate transient API errors
 	}
-	return nil
+	if exists {
+		logrus.Info("VM is already running, skipping Start")
+		return nil
+	}
+	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
+		Start(m.ctx, m.name, &kubevirtv1.StartOptions{})
 }
 
 func (m *VirtualMachineResourceManager) PowerOff() error {
-	err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
-		Stop(m.ctx, m.name, &kubevirtv1.StopOptions{})
+	exists, err := m.isVMIExists()
 	if err != nil {
-		// The VM is already stopped — the operation succeeded.
-		if strings.Contains(err.Error(), "already stopped") {
-			logrus.WithError(err).Info("VM is already stopped")
-			return nil
-		}
-		return err
+		return err // propagate transient API errors
 	}
-	return nil
+	if !exists {
+		logrus.Info("VM is already stopped, skipping Stop")
+		return nil
+	}
+	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
+		Stop(m.ctx, m.name, &kubevirtv1.StopOptions{})
+}
+
+// isVMIExists checks whether a VirtualMachineInstance exists for this VM.
+// Returns (true, nil) if the VMI exists, (false, nil) if it doesn't,
+// or (false, error) if the API call failed for any other reason.
+func (m *VirtualMachineResourceManager) isVMIExists() (bool, error) {
+	_, err := m.virtClient.KubevirtV1().VirtualMachineInstances(m.namespace).
+		Get(m.ctx, m.name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (m *VirtualMachineResourceManager) PowerCycle() error {

--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -253,44 +253,29 @@ func (m *VirtualMachineResourceManager) GetPowerStatus() (bool, error) {
 }
 
 func (m *VirtualMachineResourceManager) PowerOn() error {
-	exists, err := m.isVMIExists()
-	if err != nil {
-		return err // propagate transient API errors
-	}
-	if exists {
-		logrus.Info("VM is already running, skipping Start")
+	_, err := m.virtClient.KubevirtV1().VirtualMachineInstances(m.namespace).
+		Get(m.ctx, m.name, metav1.GetOptions{})
+	if err == nil {
 		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get VMI %s/%s: %w", m.namespace, m.name, err)
 	}
 	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
 		Start(m.ctx, m.name, &kubevirtv1.StartOptions{})
 }
 
 func (m *VirtualMachineResourceManager) PowerOff() error {
-	exists, err := m.isVMIExists()
-	if err != nil {
-		return err // propagate transient API errors
-	}
-	if !exists {
-		logrus.Info("VM is already stopped, skipping Stop")
+	_, err := m.virtClient.KubevirtV1().VirtualMachineInstances(m.namespace).
+		Get(m.ctx, m.name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get VMI %s/%s: %w", m.namespace, m.name, err)
 	}
 	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
 		Stop(m.ctx, m.name, &kubevirtv1.StopOptions{})
-}
-
-// isVMIExists checks whether a VirtualMachineInstance exists for this VM.
-// Returns (true, nil) if the VMI exists, (false, nil) if it doesn't,
-// or (false, error) if the API call failed for any other reason.
-func (m *VirtualMachineResourceManager) isVMIExists() (bool, error) {
-	_, err := m.virtClient.KubevirtV1().VirtualMachineInstances(m.namespace).
-		Get(m.ctx, m.name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func (m *VirtualMachineResourceManager) PowerCycle() error {

--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -252,46 +252,28 @@ func (m *VirtualMachineResourceManager) GetPowerStatus() (bool, error) {
 }
 
 func (m *VirtualMachineResourceManager) PowerOn() error {
-	vm, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
-		Get(m.ctx, m.name, metav1.GetOptions{})
+	err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
+		Start(m.ctx, m.name, &kubevirtv1.StartOptions{})
 	if err != nil {
-		return err
-	}
-	if vm.Spec.RunStrategy == nil {
-		running := func(b bool) *bool { return &b }(true)
-		vm.Spec.Running = running
-	} else {
-		runStrategy := func(
-			rs kubevirtv1.VirtualMachineRunStrategy,
-		) *kubevirtv1.VirtualMachineRunStrategy {
-			return &rs
-		}(kubevirtv1.RunStrategyRerunOnFailure)
-		vm.Spec.RunStrategy = runStrategy
-	}
-	if _, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
-		Update(m.ctx, vm, metav1.UpdateOptions{}); err != nil {
+		// The VM is already running — the operation succeeded.
+		if strings.Contains(err.Error(), "already running") {
+			logrus.WithError(err).Info("VM is already running")
+			return nil
+		}
 		return err
 	}
 	return nil
 }
 
 func (m *VirtualMachineResourceManager) PowerOff() error {
-	vm, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
-		Get(m.ctx, m.name, metav1.GetOptions{})
+	err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
+		Stop(m.ctx, m.name, &kubevirtv1.StopOptions{})
 	if err != nil {
-		return err
-	}
-	if vm.Spec.RunStrategy == nil {
-		running := func(b bool) *bool { return &b }(false)
-		vm.Spec.Running = running
-	} else {
-		runStrategy := func(rs kubevirtv1.VirtualMachineRunStrategy) *kubevirtv1.VirtualMachineRunStrategy {
-			return &rs
-		}(kubevirtv1.RunStrategyHalted)
-		vm.Spec.RunStrategy = runStrategy
-	}
-	if _, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
-		Update(m.ctx, vm, metav1.UpdateOptions{}); err != nil {
+		// The VM is already stopped — the operation succeeded.
+		if strings.Contains(err.Error(), "already stopped") {
+			logrus.WithError(err).Info("VM is already stopped")
+			return nil
+		}
 		return err
 	}
 	return nil
@@ -305,7 +287,8 @@ func (m *VirtualMachineResourceManager) PowerCycle() error {
 	if !isUp {
 		return m.PowerOn()
 	}
-	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).Restart(m.ctx, m.name, &kubevirtv1.RestartOptions{})
+	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
+		Restart(m.ctx, m.name, &kubevirtv1.RestartOptions{})
 }
 
 func (m *VirtualMachineResourceManager) SetBootDevice(bootDevice BootDevice) error {

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -463,35 +463,28 @@ func TestVirtualMachineResourceManager_PowerOn(t *testing.T) {
 	testCases := []struct {
 		name        string
 		vm          *kubevirtv1.VirtualMachine
-		expectedVM  *kubevirtv1.VirtualMachine
 		shouldError bool
 	}{
 		{
 			name:        "Power on a virtual machine that should be on should have no effect",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(true).Build(),
-			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(true).Build(),
 			shouldError: false,
 		},
 		{
 			name:        "Power on a virtual machine that should be off should succeed",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(false).Build(),
-			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(true).Build(),
 			shouldError: false,
 		},
 		{
 			name: "Power on a virtual machine whose RunStrategy is set to RerunOnFailure should have no effect",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				RunStrategy(kubevirtv1.RunStrategyRerunOnFailure).Build(),
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				RunStrategy(kubevirtv1.RunStrategyRerunOnFailure).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Power on a virtual machine whose RunStrategy is set to Halted should make it become RerunOnFailure",
+			name: "Power on a virtual machine whose RunStrategy is set to Halted should succeed",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				RunStrategy(kubevirtv1.RunStrategyHalted).Build(),
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				RunStrategy(kubevirtv1.RunStrategyRerunOnFailure).Build(),
 			shouldError: false,
 		},
 	}
@@ -512,12 +505,7 @@ func TestVirtualMachineResourceManager_PowerOn(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
-
 			require.NoError(t, err)
-
-			vm, err := fakeVirtClient.KubevirtV1().VirtualMachines(testNamespace).Get(context.TODO(), testVMName, metav1.GetOptions{})
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedVM, vm)
 		})
 	}
 }
@@ -526,34 +514,27 @@ func TestVirtualMachineResourceManager_PowerOff(t *testing.T) {
 	testCases := []struct {
 		name        string
 		vm          *kubevirtv1.VirtualMachine
-		expectedVM  *kubevirtv1.VirtualMachine
 		shouldError bool
 	}{
 		{
 			name:        "Power off a virtual machine that should be on should succeed",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(true).Build(),
-			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(false).Build(),
 			shouldError: false,
 		},
 		{
 			name:        "Power off a virtual machine that should be off should have no effect",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(false).Build(),
-			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(false).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Power on a virtual machine whose RunStrategy is set to RerunOnFailure should make it become Halted",
+			name: "Power off a virtual machine whose RunStrategy is set to RerunOnFailure should succeed",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				RunStrategy(kubevirtv1.RunStrategyRerunOnFailure).Build(),
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				RunStrategy(kubevirtv1.RunStrategyHalted).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Power on a virtual machine whose RunStrategy is set to Halted should have no effect",
+			name: "Power off a virtual machine whose RunStrategy is set to Halted should have no effect",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				RunStrategy(kubevirtv1.RunStrategyHalted).Build(),
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				RunStrategy(kubevirtv1.RunStrategyHalted).Build(),
 			shouldError: false,
 		},
@@ -575,12 +556,7 @@ func TestVirtualMachineResourceManager_PowerOff(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
-
 			require.NoError(t, err)
-
-			vm, err := fakeVirtClient.KubevirtV1().VirtualMachines(testNamespace).Get(context.TODO(), testVMName, metav1.GetOptions{})
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedVM, vm)
 		})
 	}
 }
@@ -599,7 +575,7 @@ func TestVirtualMachineResourceManager_PowerCycle(t *testing.T) {
 			shouldFail: false,
 		},
 		{
-			name:       "Power cycle a halted virtual machine should trigger VM start via PowerOn",
+			name:       "Power cycle a halted virtual machine should trigger VM start",
 			vm:         builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
 			vmi:        nil,
 			shouldFail: false,
@@ -627,17 +603,6 @@ func TestVirtualMachineResourceManager_PowerCycle(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-
-			vm, err := fakeVirtClient.KubevirtV1().VirtualMachines(testNamespace).Get(context.TODO(), testVMName, metav1.GetOptions{})
-			require.NoError(t, err)
-			require.NotNil(t, vm)
-
-			if tc.vmi != nil {
-				require.Equal(t, testVMName, vm.Name)
-			} else {
-				require.NotNil(t, vm.Spec.Running)
-				require.True(t, *vm.Spec.Running)
-			}
 		})
 	}
 }

--- a/test/virtbmc-agent/agent_helpers.go
+++ b/test/virtbmc-agent/agent_helpers.go
@@ -306,7 +306,7 @@ func runCurlRedfish(ctx context.Context, cfg *rest.Config, namespace string, r R
 	if r.Path != "" {
 		url = strings.TrimSuffix(r.BaseURL, "/") + r.Path
 	}
-	args := []string{"-i", "-L", "-X", r.Method}
+	args := []string{"--connect-timeout", "5", "--max-time", "15", "-i", "-L", "-X", r.Method}
 	if r.XAuthToken != "" {
 		args = append(args, "-H", "X-Auth-Token: "+r.XAuthToken)
 	} else if r.Username != "" && r.Password != "" {


### PR DESCRIPTION
Replace GET→modify→Update(PUT) pattern in PowerOn/PowerOff with KubeVirt's Start/Stop subresource APIs. This avoids race conditions and respects KubeVirt's state machine for VM lifecycle transitions.

- PowerOn: Use virtClient.KubevirtV1().VirtualMachines().Start()
- PowerOff: Use virtClient.KubevirtV1().VirtualMachines().Stop()
- PowerCycle: Use Start() subresource for halted VMs (instead of mutating spec via PowerOn), keep Restart() for running VMs
- Handle 'already running'/'already stopped' errors as success (idempotent operations that achieved the desired state)
- Add error logging in IPMI handler before returning completion codes
- Add RBAC permissions for subresources.kubevirt.io API group
- Update tests to verify operation success

fix #190