### PR TITLE
feat: Use JSON Patch for boot device operations with full device sequencing

### DIFF
--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -2,6 +2,7 @@ package resourcemanager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiclient "kubevirt.io/client-go/containerizeddataimporter"
 	kvclient "kubevirt.io/client-go/kubevirt"
@@ -291,7 +293,10 @@ func (m *VirtualMachineResourceManager) PowerCycle() error {
 }
 
 func (m *VirtualMachineResourceManager) SetBootDevice(bootDevice BootDevice) error {
-	logrus.Info("SetBootDevice")
+	logrus.Infof("SetBootDevice: %s", bootDevice)
+
+	// Fetch the VM only to discover device indices for patch paths.
+	// The actual mutation is done via JSON Patch to avoid full-UPDATE races.
 	vm, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
 		Get(m.ctx, m.name, metav1.GetOptions{})
 	if err != nil {
@@ -302,47 +307,75 @@ func (m *VirtualMachineResourceManager) SetBootDevice(bootDevice BootDevice) err
 		return fmt.Errorf("no template found")
 	}
 
-	for i, intf := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
-		logrus.Infof("interface: %+v", intf)
-		vm.Spec.Template.Spec.Domain.Devices.Interfaces[i].BootOrder = nil
-	}
-	for i, dev := range vm.Spec.Template.Spec.Domain.Devices.Disks {
-		logrus.Infof("disk: %+v", dev)
-		vm.Spec.Template.Spec.Domain.Devices.Disks[i].BootOrder = nil
+	disks := vm.Spec.Template.Spec.Domain.Devices.Disks
+	ifaces := vm.Spec.Template.Spec.Domain.Devices.Interfaces
+	if len(disks) == 0 && len(ifaces) == 0 {
+		return fmt.Errorf("no bootable devices found")
 	}
 
-	var firstOrder uint = 1
+	// Classify disks: CDROM vs regular (Disk, LUN, Floppy)
+	var cdromIndices, regularDiskIndices []int
+	for i, d := range disks {
+		if d.CDRom != nil {
+			cdromIndices = append(cdromIndices, i)
+		} else {
+			regularDiskIndices = append(regularDiskIndices, i)
+		}
+	}
+
+	// Collect interface indices; no classification needed.
+	ifaceIndices := make([]int, len(ifaces))
+	for i := range ifaceIndices {
+		ifaceIndices[i] = i
+	}
+
+	// Order device groups by boot device preference
+	var ordered []deviceGroup
 	switch bootDevice {
 	case BootDevicePxe:
-		if vm.Spec.Template.Spec.Domain.Devices.Interfaces == nil {
-			return fmt.Errorf("no interfaces found")
+		if len(ifaces) == 0 {
+			return fmt.Errorf("no interfaces found for PXE boot")
 		}
-		vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].BootOrder = &firstOrder
-		logrus.Infof("To be updated vm: %+v", vm.Spec.Template.Spec.Domain.Devices.Interfaces[0])
+		ordered = []deviceGroup{
+			{"interface", "/spec/template/spec/domain/devices/interfaces", ifaceIndices},
+			{"disk", "/spec/template/spec/domain/devices/disks", regularDiskIndices},
+			{"disk", "/spec/template/spec/domain/devices/disks", cdromIndices},
+		}
 	case BootDeviceHdd:
-		if vm.Spec.Template.Spec.Domain.Devices.Disks == nil {
-			return fmt.Errorf("no disks found")
+		if len(regularDiskIndices) == 0 {
+			return fmt.Errorf("no regular disks found for HDD boot")
 		}
-		vm.Spec.Template.Spec.Domain.Devices.Disks[0].BootOrder = &firstOrder
-		logrus.Infof("To be updated vm: %+v", vm.Spec.Template.Spec.Domain.Devices.Disks[0])
+		ordered = []deviceGroup{
+			{"disk", "/spec/template/spec/domain/devices/disks", regularDiskIndices},
+			{"interface", "/spec/template/spec/domain/devices/interfaces", ifaceIndices},
+			{"disk", "/spec/template/spec/domain/devices/disks", cdromIndices},
+		}
 	case BootDeviceCd:
-		cdromDisk, err := util.GetCdromDisk(vm.Spec.Template.Spec.Domain.Devices.Disks)
-		if err != nil {
-			return fmt.Errorf("no cdrom found: %w", err)
+		if len(cdromIndices) == 0 {
+			return fmt.Errorf("no CD-ROM found for CD boot")
 		}
-		for i, disk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
-			if disk.Name == cdromDisk.Name {
-				vm.Spec.Template.Spec.Domain.Devices.Disks[i].BootOrder = &firstOrder
-				logrus.Infof("To be updated vm: %+v", vm.Spec.Template.Spec.Domain.Devices.Disks[i])
-				break
-			}
+		ordered = []deviceGroup{
+			{"disk", "/spec/template/spec/domain/devices/disks", cdromIndices},
+			{"disk", "/spec/template/spec/domain/devices/disks", regularDiskIndices},
+			{"interface", "/spec/template/spec/domain/devices/interfaces", ifaceIndices},
 		}
+	default:
+		return nil
 	}
 
-	if _, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
-		Update(m.ctx, vm, metav1.UpdateOptions{}); err != nil {
-		logrus.Errorf("update vm error: %v", err)
-		return err
+	patchOps := buildBootOrderPatch(ordered)
+
+	if len(patchOps) > 0 {
+		patchData, err := json.Marshal(patchOps)
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON patch: %w", err)
+		}
+
+		if _, err := m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
+			Patch(m.ctx, m.name, types.JSONPatchType, patchData, metav1.PatchOptions{}); err != nil {
+			logrus.WithError(err).Error("patch vm error")
+			return err
+		}
 	}
 
 	if m.computerSystem == nil {
@@ -352,4 +385,34 @@ func (m *VirtualMachineResourceManager) SetBootDevice(bootDevice BootDevice) err
 	m.computerSystem.SetBootOverride(bootSourceMap[bootDevice])
 
 	return nil
+}
+
+// deviceGroup represents a group of devices of the same type that share a
+// common JSON Patch base path, used to order boot device priorities.
+type deviceGroup struct {
+	devType  string
+	basePath string
+	indices  []int
+}
+
+// buildBootOrderPatch creates JSON Patch operations that assign sequential
+// bootOrder values (starting from 1) to every device index across the ordered
+// groups. It uses "add" rather than "replace" because bootOrder may not exist
+// yet on the target resource — JSON Patch "add" handles both creation and
+// replacement.
+func buildBootOrderPatch(ordered []deviceGroup) []map[string]any {
+	patchOps := make([]map[string]any, 0)
+	var order uint = 1
+	for _, grp := range ordered {
+		for _, idx := range grp.indices {
+			op := map[string]any{
+				"op":    "add",
+				"path":  fmt.Sprintf("%s/%d/bootOrder", grp.basePath, idx),
+				"value": order,
+			}
+			patchOps = append(patchOps, op)
+			order++
+		}
+	}
+	return patchOps
 }

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -607,6 +607,84 @@ func TestVirtualMachineResourceManager_PowerCycle(t *testing.T) {
 	}
 }
 
+func TestBuildBootOrderPatch(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ordered  []deviceGroup
+		expected []map[string]any
+	}{
+		{
+			name:     "empty groups → no operations",
+			ordered:  []deviceGroup{},
+			expected: []map[string]any{},
+		},
+		{
+			name: "single group, single device → one op with bootOrder=1",
+			ordered: []deviceGroup{
+				{"disk", "/spec/template/spec/domain/devices/disks", []int{0}},
+			},
+			expected: []map[string]any{
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/0/bootOrder", "value": uint(1)},
+			},
+		},
+		{
+			name: "single group, multiple devices → sequential orders",
+			ordered: []deviceGroup{
+				{"disk", "/spec/template/spec/domain/devices/disks", []int{0, 2}},
+			},
+			expected: []map[string]any{
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/0/bootOrder", "value": uint(1)},
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/2/bootOrder", "value": uint(2)},
+			},
+		},
+		{
+			name: "multiple groups → sequential orders across groups",
+			ordered: []deviceGroup{
+				{"disk", "/spec/template/spec/domain/devices/disks", []int{0, 1}},
+				{"interface", "/spec/template/spec/domain/devices/interfaces", []int{0}},
+			},
+			expected: []map[string]any{
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/0/bootOrder", "value": uint(1)},
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/1/bootOrder", "value": uint(2)},
+				{"op": "add", "path": "/spec/template/spec/domain/devices/interfaces/0/bootOrder", "value": uint(3)},
+			},
+		},
+		{
+			name: "group with empty indices → skipped (no ops)",
+			ordered: []deviceGroup{
+				{"disk", "/spec/template/spec/domain/devices/disks", []int{0}},
+				{"interface", "/spec/template/spec/domain/devices/interfaces", []int{}},
+				{"disk", "/spec/template/spec/domain/devices/disks", []int{1}},
+			},
+			expected: []map[string]any{
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/0/bootOrder", "value": uint(1)},
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/1/bootOrder", "value": uint(2)},
+			},
+		},
+		{
+			name: "PXE boot order: interfaces first, then disks, then cdroms",
+			ordered: []deviceGroup{
+				{"interface", "/spec/template/spec/domain/devices/interfaces", []int{0, 1}},
+				{"disk", "/spec/template/spec/domain/devices/disks", []int{0}},
+				{"disk", "/spec/template/spec/domain/devices/disks", []int{1}},
+			},
+			expected: []map[string]any{
+				{"op": "add", "path": "/spec/template/spec/domain/devices/interfaces/0/bootOrder", "value": uint(1)},
+				{"op": "add", "path": "/spec/template/spec/domain/devices/interfaces/1/bootOrder", "value": uint(2)},
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/0/bootOrder", "value": uint(3)},
+				{"op": "add", "path": "/spec/template/spec/domain/devices/disks/1/bootOrder", "value": uint(4)},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := buildBootOrderPatch(tc.ordered)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestVirtualMachineResourceManager_SetBootDevice(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -615,320 +693,190 @@ func TestVirtualMachineResourceManager_SetBootDevice(t *testing.T) {
 		expectedVM  *kubevirtv1.VirtualMachine
 		shouldError bool
 	}{
+		// --- HDD boot ---
 		{
-			name: "Set boot device to HDD for a virtual machine with single disk should succeed",
+			name:        "HDD: single disk → bootOrder 1",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithDisk("disk", nil).Build(),
+			bootDevice:  BootDeviceHdd,
+			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithDisk("disk", util.Ptr[uint](1)).Build(),
+			shouldError: false,
+		},
+		{
+			name:        "HDD: multiple disks → sequential orders, disk first",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithDisk("disk-1", nil).WithDisk("disk-2", nil).Build(),
+			bootDevice:  BootDeviceHdd,
+			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithDisk("disk-1", util.Ptr[uint](1)).WithDisk("disk-2", util.Ptr[uint](2)).Build(),
+			shouldError: false,
+		},
+		{
+			name:        "HDD: disk + interface → disk=1, iface=2",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithDisk("disk", nil).WithInterface("iface", nil).Build(),
+			bootDevice:  BootDeviceHdd,
+			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithDisk("disk", util.Ptr[uint](1)).WithInterface("iface", util.Ptr[uint](2)).Build(),
+			shouldError: false,
+		},
+		{
+			name: "HDD: disk + cdrom + iface → disk=1, iface=2, cdrom=3 (disks first, then NICs, then CDROMs)",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).Build(),
+				WithDisk("disk", nil).WithCDRomDisk("cd", nil).WithInterface("iface", nil).Build(),
 			bootDevice: BootDeviceHdd,
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).Build(),
+				WithDisk("disk", util.Ptr[uint](1)).WithCDRomDisk("cd", util.Ptr[uint](3)).WithInterface("iface", util.Ptr[uint](2)).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Set boot device to HDD for a virtual machine with single disk whose boot order is already set to 1 should have no effect",
+			name: "HDD: pre-existing boot orders overwritten (disk=2, iface=1 → disk=1, iface=2)",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).Build(),
+				WithDisk("disk", util.Ptr[uint](2)).WithInterface("iface", util.Ptr[uint](1)).Build(),
 			bootDevice: BootDeviceHdd,
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).Build(),
+				WithDisk("disk", util.Ptr[uint](1)).WithInterface("iface", util.Ptr[uint](2)).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Set boot device to HDD for a virtual machine with single disk whose boot order is already set to 2 should bring it to 1",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](2)).Build(),
-			bootDevice: BootDeviceHdd,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to HDD for a virtual machine with multiple disks should succeed",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk-1", nil).
-				WithDisk("test-disk-2", nil).Build(),
-			bootDevice: BootDeviceHdd,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk-1", util.Ptr[uint](1)).
-				WithDisk("test-disk-2", nil).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to HDD for a virtual machine with multiple disks whose boot order is already set to 1 should have no effect",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk-1", util.Ptr[uint](1)).
-				WithDisk("test-disk-2", nil).Build(),
-			bootDevice: BootDeviceHdd,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk-1", util.Ptr[uint](1)).
-				WithDisk("test-disk-2", nil).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to HDD for a virtual machine with multiple disks whose boot order is already set to 1 should have no effect",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk-1", nil).
-				WithDisk("test-disk-2", util.Ptr[uint](1)).Build(),
-			bootDevice: BootDeviceHdd,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk-1", util.Ptr[uint](1)).
-				WithDisk("test-disk-2", nil).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to PXE for a virtual machine with single interface should succeed",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface", nil).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to PXE for a virtual machine with single interface whose boot order is already set to 1 should have no effect",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to PXE for a virtual machine with single interface whose boot order is already set to 2 should bring it to 1",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface", util.Ptr[uint](2)).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to PXE for a virtual machine with multiple interfaces should succeed",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface-1", nil).
-				WithInterface("test-interface-2", nil).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface-1", util.Ptr[uint](1)).
-				WithInterface("test-interface-2", nil).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to PXE for a virtual machine with multiple interfaces whose boot order is already set to 1 should have no effect",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface-1", util.Ptr[uint](1)).
-				WithInterface("test-interface-2", nil).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface-1", util.Ptr[uint](1)).
-				WithInterface("test-interface-2", nil).Build(),
-			shouldError: false,
-		},
-		{
-			name: "Set boot device to PXE for a virtual machine with multiple interfaces whose boot order is already set to 1 should have no effect",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface-1", nil).
-				WithInterface("test-interface-2", util.Ptr[uint](1)).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface-1", util.Ptr[uint](1)).
-				WithInterface("test-interface-2", nil).Build(),
-			shouldError: false,
-		},
-		{
-			name:        "Set boot device to HDD for a virtual machine with no disks and interfaces should fail",
+			name:        "HDD: no bootable devices → error",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
 			bootDevice:  BootDeviceHdd,
 			shouldError: true,
 		},
 		{
-			name: "Set boot device to HDD for a virtual machine with no disks but interfaces should fail",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithInterface("test-interface", nil).Build(),
+			name:        "HDD: only CDROMs → error (no regular disks)",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithCDRomDisk("cd", nil).Build(),
 			bootDevice:  BootDeviceHdd,
 			shouldError: true,
 		},
 		{
-			name:        "Set boot device to PXE for a virtual machine with no disks and interfaces should fail",
-			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
+			name:        "HDD: only interfaces → error (no disks)",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithInterface("iface", nil).Build(),
+			bootDevice:  BootDeviceHdd,
+			shouldError: true,
+		},
+		// --- PXE boot ---
+		{
+			name:        "PXE: single interface → bootOrder 1",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithInterface("iface", nil).Build(),
+			bootDevice:  BootDevicePxe,
+			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithInterface("iface", util.Ptr[uint](1)).Build(),
+			shouldError: false,
+		},
+		{
+			name:        "PXE: multiple interfaces → sequential orders",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithInterface("iface-1", nil).WithInterface("iface-2", nil).Build(),
+			bootDevice:  BootDevicePxe,
+			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithInterface("iface-1", util.Ptr[uint](1)).WithInterface("iface-2", util.Ptr[uint](2)).Build(),
+			shouldError: false,
+		},
+		{
+			name:        "PXE: iface + disk → iface=1, disk=2",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithInterface("iface", nil).WithDisk("disk", nil).Build(),
+			bootDevice:  BootDevicePxe,
+			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithInterface("iface", util.Ptr[uint](1)).WithDisk("disk", util.Ptr[uint](2)).Build(),
+			shouldError: false,
+		},
+		{
+			name: "PXE: iface + disk + cdrom → iface=1, disk=2, cdrom=3",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithInterface("iface", nil).WithDisk("disk", nil).WithCDRomDisk("cd", nil).Build(),
+			bootDevice: BootDevicePxe,
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithInterface("iface", util.Ptr[uint](1)).WithDisk("disk", util.Ptr[uint](2)).WithCDRomDisk("cd", util.Ptr[uint](3)).Build(),
+			shouldError: false,
+		},
+		{
+			name: "PXE: pre-existing boot orders overwritten (iface=2, disk=1 → iface=1, disk=2)",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithInterface("iface", util.Ptr[uint](2)).WithDisk("disk", util.Ptr[uint](1)).Build(),
+			bootDevice: BootDevicePxe,
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithInterface("iface", util.Ptr[uint](1)).WithDisk("disk", util.Ptr[uint](2)).Build(),
+			shouldError: false,
+		},
+		{
+			name: "PXE: iface + cdrom only (no regular disks) → iface=1, cdrom=2",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithInterface("iface", nil).WithCDRomDisk("cd", nil).Build(),
+			bootDevice: BootDevicePxe,
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithInterface("iface", util.Ptr[uint](1)).WithCDRomDisk("cd", util.Ptr[uint](2)).Build(),
+			shouldError: false,
+		},
+		{
+			name:        "PXE: no interfaces → error",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithDisk("disk", nil).Build(),
 			bootDevice:  BootDevicePxe,
 			shouldError: true,
 		},
 		{
-			name: "Set boot device to PXE for a virtual machine with no interfaces but disks should fail",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).Build(),
+			name:        "PXE: no devices → error",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
 			bootDevice:  BootDevicePxe,
 			shouldError: true,
 		},
+		// --- CD-ROM boot ---
 		{
-			name: "Set boot device to HDD for a virtual machine with disks and interfaces but no boot order specified should succeed",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", nil).Build(),
-			bootDevice: BootDeviceHdd,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).
-				WithInterface("test-interface", nil).Build(),
+			name:        "CD: single cdrom → bootOrder 1",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithCDRomDisk("cd", nil).Build(),
+			bootDevice:  BootDeviceCd,
+			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithCDRomDisk("cd", util.Ptr[uint](1)).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Set boot device to HDD for a virtual machine with disks and interfaces and with first boot order set to disk should have no effect",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).
-				WithInterface("test-interface", nil).Build(),
-			bootDevice: BootDeviceHdd,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).
-				WithInterface("test-interface", nil).Build(),
-			shouldError: false,
-		},
-		// {
-		// 	name: "Set boot device to HDD for a virtual machine with disks and interfaces and with first boot order set to disk should have no effect",
-		// 	vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-		// 		AddDisk("test-disk", util.Ptr[uint](1)).
-		// 		AddInterface("test-interface", util.Ptr[uint](2)).Build(),
-		// 	bootDevice: BootDeviceHdd,
-		// 	expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-		// 		AddDisk("test-disk", util.Ptr[uint](1)).
-		// 		AddInterface("test-interface", util.Ptr[uint](2)).Build(),
-		// 	shouldError: false,
-		// },
-		{
-			name: "Set boot device to HDD for a virtual machine with disks and interfaces and with first boot order set to interface should succeed",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
-			bootDevice: BootDeviceHdd,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).
-				WithInterface("test-interface", nil).Build(),
-			shouldError: false,
-		},
-		// {
-		// 	name: "Set boot device to HDD for a virtual machine with disks and interfaces and with first boot order set to interface should succeed",
-		// 	vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-		// 		AddDisk("test-disk", util.Ptr[uint](2)).
-		// 		AddInterface("test-interface", util.Ptr[uint](1)).Build(),
-		// 	bootDevice: BootDeviceHdd,
-		// 	expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-		// 		AddDisk("test-disk", util.Ptr[uint](1)).
-		// 		AddInterface("test-interface", util.Ptr[uint](2)).Build(),
-		// 	shouldError: false,
-		// },
-		{
-			name: "Set boot device to PXE for a virtual machine with disks and interfaces but no boot order specified should succeed",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", nil).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
+			name:        "CD: cdrom + disk → cdrom=1, disk=2",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithCDRomDisk("cd", nil).WithDisk("disk", nil).Build(),
+			bootDevice:  BootDeviceCd,
+			expectedVM:  builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithCDRomDisk("cd", util.Ptr[uint](1)).WithDisk("disk", util.Ptr[uint](2)).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Set boot device to PXE for a virtual machine with disks and interfaces and with first boot order set to disk should succeed",
+			name: "CD: cdrom + disk + iface → cdrom=1, disk=2, iface=3",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).
-				WithInterface("test-interface", nil).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
-			shouldError: false,
-		},
-		// {
-		// 	name: "Set boot device to PXE for a virtual machine with disks and interfaces and with first boot order set to disk should succeed",
-		// 	vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-		// 		AddDisk("test-disk", util.Ptr[uint](1)).
-		// 		AddInterface("test-interface", util.Ptr[uint](2)).Build(),
-		// 	bootDevice: BootDevicePxe,
-		// 	expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-		// 		AddDisk("test-disk", util.Ptr[uint](2)).
-		// 		AddInterface("test-interface", util.Ptr[uint](1)).Build(),
-		// 	shouldError: false,
-		// },
-		{
-			name: "Set boot device to PXE for a virtual machine with disks and interfaces and with first boot order set to interface should have no effect",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
-			bootDevice: BootDevicePxe,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", util.Ptr[uint](1)).Build(),
-			shouldError: false,
-		},
-		// {
-		// 	name: "Set boot device to PXE for a virtual machine with disks and interfaces and with first boot order set to interface should have no effect",
-		// 	vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-		// 		AddDisk("test-disk", util.Ptr[uint](2)).
-		// 		AddInterface("test-interface", util.Ptr[uint](1)).Build(),
-		// 	bootDevice: BootDevicePxe,
-		// 	expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-		// 		AddDisk("test-disk", util.Ptr[uint](2)).
-		// 		AddInterface("test-interface", util.Ptr[uint](1)).Build(),
-		// 	shouldError: false,
-		// },
-		{
-			name: "Set boot device to Cd for a virtual machine with single cdrom should succeed",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithCDRomDisk("test-cdrom", nil).Build(),
+				WithCDRomDisk("cd", nil).WithDisk("disk", nil).WithInterface("iface", nil).Build(),
 			bootDevice: BootDeviceCd,
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithCDRomDisk("test-cdrom", util.Ptr[uint](1)).Build(),
+				WithCDRomDisk("cd", util.Ptr[uint](1)).WithDisk("disk", util.Ptr[uint](2)).WithInterface("iface", util.Ptr[uint](3)).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Set boot device to Cd for a virtual machine with disk and cdrom should succeed",
+			name: "CD: pre-existing boot orders overwritten (disk=1, cdrom=nil → cdrom=1, disk=2)",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithCDRomDisk("test-cdrom", nil).Build(),
+				WithDisk("disk", util.Ptr[uint](1)).WithCDRomDisk("cd", nil).Build(),
+			bootDevice: BootDeviceCd,
+			// Device order is unchanged by Patch; only bootOrder values change.
+			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithDisk("disk", util.Ptr[uint](2)).WithCDRomDisk("cd", util.Ptr[uint](1)).Build(),
+			shouldError: false,
+		},
+		{
+			name: "CD: multiple cdroms + disk + iface → cdrom1=1, cdrom2=2, disk=3, iface=4",
+			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
+				WithCDRomDisk("cd1", nil).WithCDRomDisk("cd2", nil).
+				WithDisk("disk", nil).WithInterface("iface", nil).Build(),
 			bootDevice: BootDeviceCd,
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithCDRomDisk("test-cdrom", util.Ptr[uint](1)).Build(),
+				WithCDRomDisk("cd1", util.Ptr[uint](1)).WithCDRomDisk("cd2", util.Ptr[uint](2)).
+				WithDisk("disk", util.Ptr[uint](3)).WithInterface("iface", util.Ptr[uint](4)).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Set boot device to Cd for a virtual machine with disk, interface and cdrom should succeed and clear other boot orders",
+			name: "CD: cdrom + iface only (no regular disks) → cdrom=1, iface=2",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", util.Ptr[uint](1)).
-				WithInterface("test-interface", nil).
-				WithCDRomDisk("test-cdrom", nil).Build(),
+				WithCDRomDisk("cd", nil).WithInterface("iface", nil).Build(),
 			bootDevice: BootDeviceCd,
 			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", nil).
-				WithCDRomDisk("test-cdrom", util.Ptr[uint](1)).Build(),
+				WithCDRomDisk("cd", util.Ptr[uint](1)).WithInterface("iface", util.Ptr[uint](2)).Build(),
 			shouldError: false,
 		},
 		{
-			name: "Set boot device to Cd for a virtual machine with no cdrom should fail",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).Build(),
+			name:        "CD: no cdrom → error",
+			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).WithDisk("disk", nil).Build(),
 			bootDevice:  BootDeviceCd,
 			shouldError: true,
 		},
 		{
-			name:        "Set boot device to Cd for a virtual machine with no disks should fail",
+			name:        "CD: no devices → error",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
 			bootDevice:  BootDeviceCd,
 			shouldError: true,
-		},
-		{
-			name: "Set boot device to Cd for a virtual machine with disk, interface and cdrom with existing boot order should succeed",
-			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", util.Ptr[uint](1)).
-				WithCDRomDisk("test-cdrom", nil).Build(),
-			bootDevice: BootDeviceCd,
-			expectedVM: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
-				WithDisk("test-disk", nil).
-				WithInterface("test-interface", nil).
-				WithCDRomDisk("test-cdrom", util.Ptr[uint](1)).Build(),
-			shouldError: false,
 		},
 	}
 	for _, tc := range testCases {

--- a/test/virtbmc-agent/agent_helpers.go
+++ b/test/virtbmc-agent/agent_helpers.go
@@ -142,6 +142,38 @@ func waitForVMIPowerCycle(ctx context.Context, k8sClient client.Client, namespac
 		"VMI %s/%s should be recreated with a new UID and reach Running phase", namespace, agentVMName)
 }
 
+// verifyVMBootOrder fetches the test VM and checks that bootOrder values on
+// disks and interfaces match the expected maps. It retries until the timeout
+// because the update goes through agent → resourcemanager → KubeVirt API.
+func verifyVMBootOrder(ctx context.Context, k8sClient client.Client, namespace string, expectedDisks, expectedIfaces map[int]uint) {
+	Eventually(func() bool {
+		vm := &kubevirtv1.VirtualMachine{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: agentVMName}, vm); err != nil {
+			return false
+		}
+		if vm.Spec.Template == nil {
+			return false
+		}
+
+		disks := vm.Spec.Template.Spec.Domain.Devices.Disks
+		ifaces := vm.Spec.Template.Spec.Domain.Devices.Interfaces
+
+		for idx, expectedOrder := range expectedDisks {
+			if idx >= len(disks) || disks[idx].BootOrder == nil || *disks[idx].BootOrder != expectedOrder {
+				return false
+			}
+		}
+		for idx, expectedOrder := range expectedIfaces {
+			if idx >= len(ifaces) || ifaces[idx].BootOrder == nil || *ifaces[idx].BootOrder != expectedOrder {
+				return false
+			}
+		}
+		return true
+	}, vmPowerStatusTimeout, agentTestInterval).Should(BeTrue(),
+		"VM %s/%s boot order should match: disks=%v ifaces=%v",
+		namespace, agentVMName, expectedDisks, expectedIfaces)
+}
+
 func (e *agentTestEnv) ensureSecretExists(ctx context.Context, k8sClient client.Client, namespace string) error {
 	secret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: agentSecretName}, secret); err != nil {

--- a/test/virtbmc-agent/agent_test.go
+++ b/test/virtbmc-agent/agent_test.go
@@ -133,6 +133,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					ContainSubstring("Boot"),
 					Equal(""),
 				))
+				// PXE: interfaces first, then regular disks, then cdroms
+				verifyVMBootOrder(ctx, k8sClient, ns,
+					map[int]uint{0: 2, 1: 3}, // disks: regular=2, cdrom=3
+					map[int]uint{0: 1},       // interface=1
+				)
 			})
 
 			It("should set boot device to disk", func() {
@@ -143,6 +148,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					ContainSubstring("Boot"),
 					Equal(""),
 				))
+				// HDD: regular disks first, then interfaces, then cdroms
+				verifyVMBootOrder(ctx, k8sClient, ns,
+					map[int]uint{0: 1, 1: 3}, // disks: regular=1, cdrom=3
+					map[int]uint{0: 2},       // interface=2
+				)
 			})
 
 			It("should set boot device to cdrom", func() {
@@ -153,6 +163,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					ContainSubstring("Boot"),
 					Equal(""),
 				))
+				// CD: cdroms first, then regular disks, then interfaces
+				verifyVMBootOrder(ctx, k8sClient, ns,
+					map[int]uint{0: 2, 1: 1}, // disks: regular=2, cdrom=1
+					map[int]uint{0: 3},       // interface=3
+				)
 			})
 		})
 	})
@@ -238,6 +253,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					ContainSubstring("200"),
 					ContainSubstring("204"),
 				))
+				// PXE: interfaces first, then regular disks, then cdroms
+				verifyVMBootOrder(ctx, k8sClient, ns,
+					map[int]uint{0: 2, 1: 3}, // disks: regular=2, cdrom=3
+					map[int]uint{0: 1},       // interface=1
+				)
 			})
 
 			It("should set boot to PXE continuous", func() {
@@ -248,6 +268,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					ContainSubstring("200"),
 					ContainSubstring("204"),
 				))
+				// PXE: interfaces first, then regular disks, then cdroms
+				verifyVMBootOrder(ctx, k8sClient, ns,
+					map[int]uint{0: 2, 1: 3}, // disks: regular=2, cdrom=3
+					map[int]uint{0: 1},       // interface=1
+				)
 			})
 
 			It("should set boot to disk", func() {
@@ -258,6 +283,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					ContainSubstring("200"),
 					ContainSubstring("204"),
 				))
+				// HDD: regular disks first, then interfaces, then cdroms
+				verifyVMBootOrder(ctx, k8sClient, ns,
+					map[int]uint{0: 1, 1: 3}, // disks: regular=1, cdrom=3
+					map[int]uint{0: 2},       // interface=2
+				)
 			})
 
 			It("should set boot to Cd", func() {
@@ -268,6 +298,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					ContainSubstring("200"),
 					ContainSubstring("204"),
 				))
+				// CD: cdroms first, then regular disks, then interfaces
+				verifyVMBootOrder(ctx, k8sClient, ns,
+					map[int]uint{0: 2, 1: 1}, // disks: regular=2, cdrom=1
+					map[int]uint{0: 3},       // interface=3
+				)
 			})
 
 			It("should set boot mode to UEFI", func() {


### PR DESCRIPTION
fix #184 

Replace the GET→modify→Update(PUT) pattern in SetBootDevice with targeted JSON Patch operations. Each device's bootOrder is set via individual 'add' patch op, preserving all other VM properties.

Also implements proper IPMI boot order semantics by sequencing ALL devices by category with the chosen category first:

  PXE:   NICs(1,2,3) → Disks(4,5,6) → CDROMs(7,8,9)
  HDD:   Disks(1,2,3) → NICs(4,5,6) → CDROMs(7,8,9)
  CDROM: CDROMs(1,2,3) → Disks(4,5,6) → NICs(7,8,9)

Devices are classified as: CDROM (disk.CDRom != nil), regular disk (Disk, LUN, Floppy), or NIC (interface). JSON Patch 'add' operation is used (not 'replace') to handle both existing and absent bootOrder fields.