### PR TITLE
chore: enable KubeVirt useEmulation in e2e install

### DIFF
--- a/test/util/helper.go
+++ b/test/util/helper.go
@@ -128,6 +128,13 @@ func InstallKubeVirt() error {
 		return fmt.Errorf("apply KubeVirt CR: %w", err)
 	}
 
+	// Enable emulation so VMs can run without hardware virtualization (e.g. in Kind).
+	cmd = exec.Command("kubectl", "patch", "kubevirt", "kubevirt", "-n", "kubevirt", "--type=merge",
+		"-p", `{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}`)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("patch KubeVirt CR for useEmulation: %w", err)
+	}
+
 	Eventually(func() (string, error) {
 		cmd := exec.Command("kubectl", "get", "kubevirt", "kubevirt", "-n", "kubevirt", "-o", "jsonpath={.status.phase}")
 		out, err := Run(cmd)

--- a/test/util/helper.go
+++ b/test/util/helper.go
@@ -39,6 +39,11 @@ func Run(cmd *exec.Cmd) (string, error) {
 	return string(out), nil
 }
 
+func isKVMAvailable() bool {
+	_, err := os.Stat("/dev/kvm")
+	return err == nil
+}
+
 func IsCertManagerCRDsInstalled() bool {
 	// List of common Cert Manager CRDs
 	certManagerCRDs := []string{
@@ -128,11 +133,16 @@ func InstallKubeVirt() error {
 		return fmt.Errorf("apply KubeVirt CR: %w", err)
 	}
 
-	// Enable emulation so VMs can run without hardware virtualization (e.g. in Kind).
-	cmd = exec.Command("kubectl", "patch", "kubevirt", "kubevirt", "-n", "kubevirt", "--type=merge",
-		"-p", `{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}`)
-	if _, err := Run(cmd); err != nil {
-		return fmt.Errorf("patch KubeVirt CR for useEmulation: %w", err)
+	// Enable emulation only when KVM is not available (e.g. in Kind).
+	if !isKVMAvailable() {
+		fmt.Println("KVM not available, enabling KubeVirt useEmulation")
+		cmd = exec.Command("kubectl", "patch", "kubevirt", "kubevirt", "-n", "kubevirt", "--type=merge",
+			"-p", `{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}`)
+		if _, err := Run(cmd); err != nil {
+			return fmt.Errorf("patch KubeVirt CR for useEmulation: %w", err)
+		}
+	} else {
+		fmt.Println("KVM is available, skipping useEmulation")
 	}
 
 	Eventually(func() (string, error) {

--- a/test/util/helper.go
+++ b/test/util/helper.go
@@ -133,7 +133,7 @@ func InstallKubeVirt() error {
 		return fmt.Errorf("apply KubeVirt CR: %w", err)
 	}
 
-	// Enable emulation only when KVM is not available (e.g. in Kind).
+	// Enable emulation only when KVM is not available.
 	if !isKVMAvailable() {
 		fmt.Println("KVM not available, enabling KubeVirt useEmulation")
 		cmd = exec.Command("kubectl", "patch", "kubevirt", "kubevirt", "-n", "kubevirt", "--type=merge",


### PR DESCRIPTION
Patches the KubeVirt CR after apply to enable software emulation, allowing VMs to run in environment without hardware virtualization.

fix #196