### PR TITLE
fix: ipmi authorization

### DIFF
--- a/pkg/ipmi/simulator.go
+++ b/pkg/ipmi/simulator.go
@@ -1,22 +1,54 @@
 package ipmi
 
 import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/binary"
+	"hash/adler32"
 	"net"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	goipmi "github.com/vmware/goipmi"
+
 	"kubevirt.io/kubevirtbmc/pkg/resourcemanager"
 )
 
+// Command-specific completion codes for IPMI session management.
+// These are in the 0x80-0xBE range per the IPMI spec (section 5.2).
+const (
+	// ActivateSession (22.17): auth failure / invalid AuthCode
+	ccInvalidAuthCode = goipmi.CompletionCode(0x85)
+	// ActivateSession (22.17): invalid session ID
+	ccInvalidSessionID = goipmi.CompletionCode(0x86)
+)
+
+// v15Session holds state for an IPMI v1.5 session challenge-response handshake.
+type v15Session struct {
+	username  string
+	challenge [16]byte
+}
+
+// Simulator provides an IPMI BMC simulator.
 type Simulator struct {
 	ip   string
 	port int
 
 	handler *handler
 	sim     *goipmi.Simulator
+
+	// Authentication credentials
+	username string
+	password string
+
+	// v1.5 session state (temporary session ID -> session state)
+	v15Sessions   map[uint32]*v15Session
+	v15SessionsMu sync.Mutex
 }
 
-func NewSimulator(ip string, port int, resourceManager resourcemanager.ResourceManager) *Simulator {
+// NewSimulator creates a new IPMI simulator with the given credentials.
+func NewSimulator(ip string, port int, resourceManager resourcemanager.ResourceManager, username, password string) *Simulator {
 	return &Simulator{
 		ip:   ip,
 		port: port,
@@ -26,10 +58,14 @@ func NewSimulator(ip string, port int, resourceManager resourcemanager.ResourceM
 			IP:   net.ParseIP(ip).To4(),
 			Port: port,
 		}),
+		username:    username,
+		password:    password,
+		v15Sessions: map[uint32]*v15Session{},
 	}
 }
 
 func (s *Simulator) initialize() {
+	// Override chassis command handlers
 	s.sim.SetHandler(
 		goipmi.NetworkFunctionChassis,
 		goipmi.CommandChassisStatus,
@@ -45,6 +81,174 @@ func (s *Simulator) initialize() {
 		goipmi.CommandSetSystemBootOptions,
 		s.handler.setSystemBootOptionsHandler,
 	)
+
+	// Override session management handlers with authenticated versions
+	s.sim.SetHandler(
+		goipmi.NetworkFunctionApp,
+		goipmi.CommandGetSessionChallenge,
+		s.handleSessionChallenge,
+	)
+	s.sim.SetHandler(
+		goipmi.NetworkFunctionApp,
+		goipmi.CommandActivateSession,
+		s.handleActivateSession,
+	)
+}
+
+// handleSessionChallenge validates the username and returns a random challenge.
+func (s *Simulator) handleSessionChallenge(m *goipmi.Message) goipmi.Response {
+	r := &goipmi.SessionChallengeRequest{}
+	if err := m.Request(r); err != nil {
+		return err
+	}
+
+	// Extract username from the 16-byte username field (trim null bytes)
+	username := string(bytes.TrimRight(r.Username[:], "\x00"))
+
+	return s.processSessionChallenge(username)
+}
+
+// processSessionChallenge is the testable core of handleSessionChallenge.
+func (s *Simulator) processSessionChallenge(username string) goipmi.Response {
+	if username != s.username {
+		logrus.Warnf("IPMI v1.5 session challenge: invalid username %q", username)
+		return &goipmi.SessionChallengeResponse{
+			CompletionCode: ccInvalidAuthCode,
+		}
+	}
+
+	// Generate a temporary session ID from the username hash
+	hash := adler32.New()
+	hash.Write([]byte(username))
+	id := hash.Sum32()
+
+	// Generate a random challenge
+	var challenge [16]byte
+	_, _ = rand.Read(challenge[:])
+
+	s.v15SessionsMu.Lock()
+	s.v15Sessions[id] = &v15Session{username: username, challenge: challenge}
+	s.v15SessionsMu.Unlock()
+
+	logrus.Debugf("IPMI v1.5 session challenge: user=%q sessionID=0x%08x", username, id)
+
+	return &goipmi.SessionChallengeResponse{
+		CompletionCode:     goipmi.CommandCompleted,
+		TemporarySessionID: id,
+		Challenge:          challenge,
+	}
+}
+
+// handleActivateSession validates the password and activates a v1.5 session.
+func (s *Simulator) handleActivateSession(m *goipmi.Message) goipmi.Response {
+	r := &goipmi.ActivateSessionRequest{}
+	if err := m.Request(r); err != nil {
+		return err
+	}
+
+	// Reconstruct the IPMI payload bytes for multi-session auth code validation.
+	// Per IPMI spec section 22.17.1:
+	//   Multi-session AuthCode = MD5(password[16] | sessionID[4] | ipmi_payload | seq[4] | password[16])
+	//   where ipmi_payload = RsAddr | NetFnRsLUN | Checksum1 | RqAddr | RqSeq | Command | Data | Checksum2
+	// The trailing checksum (Checksum2) is included because ipmitool (and the goipmi client)
+	// compute the AuthCode over the full serialized IPMI message starting at RsAddr.
+	ipmiPayload := make([]byte, 7+len(m.Data))
+	ipmiPayload[0] = m.RsAddr
+	ipmiPayload[1] = m.NetFnRsLUN
+	ipmiPayload[2] = m.Checksum
+	ipmiPayload[3] = m.RqAddr
+	ipmiPayload[4] = m.RqSeq
+	ipmiPayload[5] = uint8(m.Command)
+	copy(ipmiPayload[6:], m.Data)
+	// Recompute Checksum2 the same way goipmi does.
+	ipmiPayload[6+len(m.Data)] = payloadChecksum(m.RqAddr, m.RqSeq, uint8(m.Command), m.Data)
+
+	return s.processActivateSession(m.SessionID, r.AuthType, m.Sequence, m.AuthCode, ipmiPayload)
+}
+
+// processActivateSession is the testable core of handleActivateSession.
+func (s *Simulator) processActivateSession(sessionID uint32, authType uint8, sequence uint32, sessionAuthCode [16]byte, ipmiPayload []byte) goipmi.Response {
+	s.v15SessionsMu.Lock()
+	sess := s.v15Sessions[sessionID]
+	s.v15SessionsMu.Unlock()
+
+	if sess == nil {
+		logrus.Warnf("IPMI v1.5 activate session: unknown session ID 0x%08x", sessionID)
+		return &goipmi.ActivateSessionResponse{
+			CompletionCode: ccInvalidSessionID,
+		}
+	}
+
+	// Validate the multi-session AuthCode from the session header.
+	// Per IPMI spec section 22.17.1:
+	//   Multi-session AuthCode = MD5(password[16] | sessionID[4] | ipmi_payload | seq[4] | password[16])
+	//   For AuthType=Password: AuthCode = password padded to 16 bytes
+	//   For AuthType=None: no validation
+	if authType != goipmi.AuthTypeNone {
+		expectedAuthCode := computeMultiSessionAuthCode(s.password, sessionID, sequence, ipmiPayload, authType)
+		if expectedAuthCode != sessionAuthCode {
+			logrus.Warnf("IPMI v1.5 activate session: invalid password for user %q", sess.username)
+			return &goipmi.ActivateSessionResponse{
+				CompletionCode: ccInvalidAuthCode,
+			}
+		}
+	}
+
+	logrus.Infof("IPMI v1.5 session activated: user=%q sessionID=0x%08x", sess.username, sessionID)
+
+	return &goipmi.ActivateSessionResponse{
+		CompletionCode: goipmi.CommandCompleted,
+		AuthType:       authType,
+		SessionID:      sessionID,
+		InboundSeq:     sequence,
+		MaxPriv:        goipmi.PrivLevelAdmin,
+	}
+}
+
+// computeMultiSessionAuthCode computes the IPMI v1.5 multi-session AuthCode.
+// Per IPMI spec section 22.17.1:
+//
+//	AuthCode = MD5(password[16] | sessionID[4] | ipmi_payload[N] | seq[4] | password[16])
+//
+// For AuthType=Password, the AuthCode is the password padded to 16 bytes.
+func computeMultiSessionAuthCode(password string, sessionID uint32, sequence uint32, ipmiPayload []byte, authType uint8) [16]byte {
+	key := make([]byte, 16)
+	copy(key, password)
+
+	if authType == goipmi.AuthTypePassword {
+		var authCode [16]byte
+		copy(authCode[:], key)
+		return authCode
+	}
+
+	// AuthTypeMD5: MD5(password[16] | sessionID[4] | ipmi_payload[N] | seq[4] | password[16])
+	inputLen := 16 + 4 + len(ipmiPayload) + 4 + 16
+	input := make([]byte, inputLen)
+
+	off := 0
+	copy(input[off:], key)
+	off += 16
+	binary.LittleEndian.PutUint32(input[off:], sessionID)
+	off += 4
+	copy(input[off:], ipmiPayload)
+	off += len(ipmiPayload)
+	binary.LittleEndian.PutUint32(input[off:], sequence)
+	off += 4
+	copy(input[off:], key)
+
+	return md5.Sum(input)
+}
+
+// payloadChecksum computes the IPMI payload checksum (Checksum2).
+func payloadChecksum(rqAddr, rqSeq, cmd uint8, data []byte) uint8 {
+	var c uint8
+	c += rqAddr
+	c += rqSeq
+	c += cmd
+	for _, b := range data {
+		c += b
+	}
+	return -c
 }
 
 func (s *Simulator) Run() error {
@@ -54,5 +258,5 @@ func (s *Simulator) Run() error {
 
 func (s *Simulator) Stop() {
 	s.sim.Stop()
-	logrus.Info("Redfish emulator gracefully stopped")
+	logrus.Info("IPMI simulator gracefully stopped")
 }

--- a/pkg/ipmi/simulator_test.go
+++ b/pkg/ipmi/simulator_test.go
@@ -1,0 +1,275 @@
+package ipmi
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	goipmi "github.com/vmware/goipmi"
+	"go.uber.org/mock/gomock"
+
+	"kubevirt.io/kubevirtbmc/pkg/resourcemanager"
+)
+
+func TestProcessSessionChallengeValidUsername(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRM := resourcemanager.NewMockResourceManager(ctrl)
+	sim := NewSimulator("127.0.0.1", 623, mockRM, "admin", "password")
+
+	response := sim.processSessionChallenge("admin")
+
+	res, ok := response.(*goipmi.SessionChallengeResponse)
+	assert.True(t, ok, "expected *SessionChallengeResponse, got %T", response)
+	assert.Equal(t, goipmi.CommandCompleted, res.CompletionCode)
+	assert.NotZero(t, res.TemporarySessionID)
+	assert.NotEqual(t, [16]byte{}, res.Challenge, "challenge should not be zero")
+}
+
+func TestProcessSessionChallengeInvalidUsername(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRM := resourcemanager.NewMockResourceManager(ctrl)
+	sim := NewSimulator("127.0.0.1", 623, mockRM, "admin", "password")
+
+	response := sim.processSessionChallenge("attacker")
+
+	res, ok := response.(*goipmi.SessionChallengeResponse)
+	assert.True(t, ok, "expected *SessionChallengeResponse, got %T", response)
+	assert.Equal(t, ccInvalidAuthCode, res.CompletionCode)
+}
+
+// buildActivateIPMIPayload constructs the ipmiPayload for multi-session AuthCode validation.
+// Reconstructs: RsAddr | NetFnRsLUN | Checksum1 | RqAddr | RqSeq | Command | Data | Checksum2
+func buildActivateIPMIPayload(req *goipmi.ActivateSessionRequest) []byte {
+	// Serialize the ActivateSessionRequest to get the Data portion
+	data := make([]byte, 1+1+16+4)
+	data[0] = req.AuthType
+	data[1] = req.PrivLevel
+	copy(data[2:18], req.AuthCode[:])
+	binary.LittleEndian.PutUint32(data[18:22], binary.LittleEndian.Uint32(req.InSeq[:]))
+
+	rqAddr := uint8(0x81) // remoteSWID
+	rqSeq := uint8(0x08)  // rqSeq << 2 | lun
+	cmd := uint8(goipmi.CommandActivateSession)
+
+	ipmiPayload := make([]byte, 7+len(data))
+	ipmiPayload[0] = 0x20 // RsAddr (bmcSlaveAddr)
+	ipmiPayload[1] = 0x18 // NetFnRsLUN (App netfn << 2 | lun)
+	ipmiPayload[2] = goipmiChecksum(0x20, 0x18)
+	ipmiPayload[3] = rqAddr
+	ipmiPayload[4] = rqSeq
+	ipmiPayload[5] = cmd
+	copy(ipmiPayload[6:], data)
+	// Checksum2 = -(rqAddr + rqSeq + cmd + sum(data))
+	var cs2 uint8
+	cs2 += rqAddr
+	cs2 += rqSeq
+	cs2 += cmd
+	for _, b := range data {
+		cs2 += b
+	}
+	ipmiPayload[6+len(data)] = -cs2
+	return ipmiPayload
+}
+
+func goipmiChecksum(b ...uint8) uint8 {
+	var c uint8
+	for _, x := range b {
+		c += x
+	}
+	return -c
+}
+
+func TestProcessActivateSessionValidPasswordMD5(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRM := resourcemanager.NewMockResourceManager(ctrl)
+	sim := NewSimulator("127.0.0.1", 623, mockRM, "admin", "testpass")
+
+	// Step 1: Get a session challenge
+	challengeRes := sim.processSessionChallenge("admin")
+	challengeResp := challengeRes.(*goipmi.SessionChallengeResponse)
+	assert.Equal(t, goipmi.CommandCompleted, challengeResp.CompletionCode)
+
+	// Step 2: Build ActivateSession request and compute the multi-session AuthCode
+	authType := uint8(goipmi.AuthTypeMD5)
+	sequence := uint32(0)
+
+	// Build the ActivateSessionRequest to construct the IPMI payload
+	activateReq := &goipmi.ActivateSessionRequest{
+		AuthType:  authType,
+		PrivLevel: goipmi.PrivLevelAdmin,
+	}
+	binary.LittleEndian.PutUint32(activateReq.InSeq[:], sequence)
+	ipmiPayload := buildActivateIPMIPayload(activateReq)
+
+	// Compute the expected multi-session AuthCode
+	expectedAuthCode := computeMultiSessionAuthCode("testpass", challengeResp.TemporarySessionID, sequence, ipmiPayload, authType)
+
+	activateRes := sim.processActivateSession(challengeResp.TemporarySessionID, authType, sequence, expectedAuthCode, ipmiPayload)
+	activateResp, ok := activateRes.(*goipmi.ActivateSessionResponse)
+	assert.True(t, ok, "expected *ActivateSessionResponse, got %T", activateRes)
+	assert.Equal(t, goipmi.CommandCompleted, activateResp.CompletionCode)
+	assert.Equal(t, uint8(goipmi.PrivLevelAdmin), activateResp.MaxPriv)
+}
+
+func TestProcessActivateSessionInvalidPasswordMD5(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRM := resourcemanager.NewMockResourceManager(ctrl)
+	sim := NewSimulator("127.0.0.1", 623, mockRM, "admin", "correctpass")
+
+	// Step 1: Get a session challenge
+	challengeRes := sim.processSessionChallenge("admin")
+	challengeResp := challengeRes.(*goipmi.SessionChallengeResponse)
+	assert.Equal(t, goipmi.CommandCompleted, challengeResp.CompletionCode)
+
+	// Step 2: Compute AuthCode with WRONG password
+	authType := uint8(goipmi.AuthTypeMD5)
+	sequence := uint32(0)
+
+	activateReq := &goipmi.ActivateSessionRequest{
+		AuthType:  authType,
+		PrivLevel: goipmi.PrivLevelAdmin,
+	}
+	ipmiPayload := buildActivateIPMIPayload(activateReq)
+	wrongAuthCode := computeMultiSessionAuthCode("wrongpass", challengeResp.TemporarySessionID, sequence, ipmiPayload, authType)
+
+	activateRes := sim.processActivateSession(challengeResp.TemporarySessionID, authType, sequence, wrongAuthCode, ipmiPayload)
+	activateResp := activateRes.(*goipmi.ActivateSessionResponse)
+	assert.Equal(t, ccInvalidAuthCode, activateResp.CompletionCode,
+		"should reject session activation with wrong password")
+}
+
+func TestProcessActivateSessionValidPasswordAuthTypePassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRM := resourcemanager.NewMockResourceManager(ctrl)
+	sim := NewSimulator("127.0.0.1", 623, mockRM, "admin", "testpass")
+
+	// Step 1: Get a session challenge
+	challengeRes := sim.processSessionChallenge("admin")
+	challengeResp := challengeRes.(*goipmi.SessionChallengeResponse)
+	assert.Equal(t, goipmi.CommandCompleted, challengeResp.CompletionCode)
+
+	// Step 2: Activate with Password auth type - auth code is the password padded to 16 bytes
+	authType := uint8(goipmi.AuthTypePassword)
+	sequence := uint32(0)
+
+	activateReq := &goipmi.ActivateSessionRequest{
+		AuthType:  authType,
+		PrivLevel: goipmi.PrivLevelAdmin,
+	}
+	ipmiPayload := buildActivateIPMIPayload(activateReq)
+	expectedAuthCode := computeMultiSessionAuthCode("testpass", challengeResp.TemporarySessionID, sequence, ipmiPayload, authType)
+
+	activateRes := sim.processActivateSession(challengeResp.TemporarySessionID, authType, sequence, expectedAuthCode, ipmiPayload)
+	activateResp := activateRes.(*goipmi.ActivateSessionResponse)
+	assert.Equal(t, goipmi.CommandCompleted, activateResp.CompletionCode)
+}
+
+func TestProcessActivateSessionWrongPasswordAuthTypePassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRM := resourcemanager.NewMockResourceManager(ctrl)
+	sim := NewSimulator("127.0.0.1", 623, mockRM, "admin", "correctpass")
+
+	// Step 1: Get a session challenge
+	challengeRes := sim.processSessionChallenge("admin")
+	challengeResp := challengeRes.(*goipmi.SessionChallengeResponse)
+	assert.Equal(t, goipmi.CommandCompleted, challengeResp.CompletionCode)
+
+	// Step 2: Activate with WRONG password
+	authType := uint8(goipmi.AuthTypePassword)
+	sequence := uint32(0)
+
+	activateReq := &goipmi.ActivateSessionRequest{
+		AuthType:  authType,
+		PrivLevel: goipmi.PrivLevelAdmin,
+	}
+	ipmiPayload := buildActivateIPMIPayload(activateReq)
+	wrongAuthCode := computeMultiSessionAuthCode("wrongpass", challengeResp.TemporarySessionID, sequence, ipmiPayload, authType)
+
+	activateRes := sim.processActivateSession(challengeResp.TemporarySessionID, authType, sequence, wrongAuthCode, ipmiPayload)
+	activateResp := activateRes.(*goipmi.ActivateSessionResponse)
+	assert.Equal(t, ccInvalidAuthCode, activateResp.CompletionCode,
+		"should reject session activation with wrong password (AuthType=Password)")
+}
+
+func TestProcessActivateSessionUnknownSessionID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRM := resourcemanager.NewMockResourceManager(ctrl)
+	sim := NewSimulator("127.0.0.1", 623, mockRM, "admin", "password")
+
+	activateRes := sim.processActivateSession(0xdeadbeef, goipmi.AuthTypeMD5, 0, [16]byte{}, nil)
+	activateResp := activateRes.(*goipmi.ActivateSessionResponse)
+	assert.Equal(t, ccInvalidSessionID, activateResp.CompletionCode,
+		"should reject unknown session ID")
+}
+
+func TestComputeMultiSessionAuthCodeMD5(t *testing.T) {
+	password := "testpass"
+	var sessionID uint32 = 0x12345678
+	var sequence uint32 = 0x00000001
+	ipmiPayload := []byte{0x20, 0x18, 0xc8, 0x81, 0x08, 0x3a, 0x02, 0x04}
+	authType := uint8(goipmi.AuthTypeMD5)
+
+	authCode := computeMultiSessionAuthCode(password, sessionID, sequence, ipmiPayload, authType)
+
+	// Manually compute expected
+	key := make([]byte, 16)
+	copy(key, password)
+	inputLen := 16 + 4 + len(ipmiPayload) + 4 + 16
+	input := make([]byte, inputLen)
+	off := 0
+	copy(input[off:], key)
+	off += 16
+	binary.LittleEndian.PutUint32(input[off:], sessionID)
+	off += 4
+	copy(input[off:], ipmiPayload)
+	off += len(ipmiPayload)
+	binary.LittleEndian.PutUint32(input[off:], sequence)
+	off += 4
+	copy(input[off:], key)
+	expected := md5.Sum(input)
+
+	assert.Equal(t, expected, authCode)
+}
+
+func TestComputeMultiSessionAuthCodePasswordAuthType(t *testing.T) {
+	password := "mypassword"
+	authCode := computeMultiSessionAuthCode(password, 0, 0, nil, goipmi.AuthTypePassword)
+
+	// For AuthType=Password, the auth code is the password padded to 16 bytes
+	expected := [16]byte{}
+	copy(expected[:], password)
+	assert.Equal(t, expected, authCode)
+}
+
+func TestProcessActivateSessionAuthTypeNoneSkipsValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRM := resourcemanager.NewMockResourceManager(ctrl)
+	sim := NewSimulator("127.0.0.1", 623, mockRM, "admin", "password")
+
+	// Step 1: Get a session challenge
+	challengeRes := sim.processSessionChallenge("admin")
+	challengeResp := challengeRes.(*goipmi.SessionChallengeResponse)
+	assert.Equal(t, goipmi.CommandCompleted, challengeResp.CompletionCode)
+
+	// Step 2: Activate with AuthType=None - should skip validation entirely
+	activateRes := sim.processActivateSession(challengeResp.TemporarySessionID, goipmi.AuthTypeNone, 0, [16]byte{}, nil)
+	activateResp := activateRes.(*goipmi.ActivateSessionResponse)
+	assert.Equal(t, goipmi.CommandCompleted, activateResp.CompletionCode)
+}

--- a/pkg/virtbmc/virtbmc.go
+++ b/pkg/virtbmc/virtbmc.go
@@ -52,7 +52,7 @@ func NewVirtBMC(ctx context.Context, options Options, inCluster bool) (*VirtBMC,
 
 	var ipmiSimulator *ipmi.Simulator
 	if options.EnableIPMI {
-		ipmiSimulator = ipmi.NewSimulator(options.Address, options.IPMIPort, resourceManager)
+		ipmiSimulator = ipmi.NewSimulator(options.Address, options.IPMIPort, resourceManager, options.BMCUser, options.BMCPassword)
 	}
 
 	return &VirtBMC{

--- a/test/virtbmc-agent/agent_helpers.go
+++ b/test/virtbmc-agent/agent_helpers.go
@@ -351,23 +351,22 @@ type IPMIRequest struct {
 	Args        []string
 }
 
-func runIPMIInCluster(ctx context.Context, cfg *rest.Config, namespace string, r IPMIRequest) (string, error) {
+func runIPMIInCluster(ctx context.Context, cfg *rest.Config, namespace string, r IPMIRequest) (stdout, stderr string, err error) {
 	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		return "", fmt.Errorf("building clientset: %w", err)
+		return "", "", fmt.Errorf("building clientset: %w", err)
 	}
 	if err := CreateIPMIToolPod(ctx, clientset, namespace); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	baseArgs := []string{"ipmitool", "-I", "lan", "-U", r.Username, "-P", r.Password, "-H", r.ServiceHost}
 	cmd := append(baseArgs, r.Args...)
 
-	stdout, _, err := execInPod(ctx, cfg, clientset, execOptions{
+	return execInPod(ctx, cfg, clientset, execOptions{
 		Namespace:     namespace,
 		PodName:       ipmitoolPodName,
 		ContainerName: "ipmitool",
 		Command:       cmd,
 	})
-	return stdout, err
 }

--- a/test/virtbmc-agent/agent_test.go
+++ b/test/virtbmc-agent/agent_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 	Context("IPMI enable/disable toggle", func() {
 		It("should start with IPMI disabled by default, verify failure, then enable", func() {
 			By("verifying IPMI commands fail when disabled by default")
-			_, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
+			_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
 			Expect(err).To(HaveOccurred(), "IPMI command should fail when IPMI is disabled")
 
 			By("recording the current pod UID before enabling IPMI")
@@ -95,9 +95,40 @@ var _ = Describe("Agent e2e", Ordered, func() {
 	})
 
 	Context("IPMI operations", func() {
+		Context("Authentication", func() {
+			It("should accept commands with correct username and password", func() {
+				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(SatisfyAny(
+					ContainSubstring("Chassis Power is on"),
+					ContainSubstring("Chassis Power is off"),
+				))
+			})
+
+			It("should reject commands with wrong password", func() {
+				wrongReq := ipmiReq("power", "status")
+				wrongReq.Password = "wrongpass"
+				_, stderr, err := runIPMIInCluster(ctx, config, ns, wrongReq)
+				Expect(err).To(HaveOccurred(), "IPMI command with wrong password should be rejected")
+				Expect(stderr).To(ContainSubstring("Unable to establish IPMI v1.5 / RMCP session"))
+			})
+
+			It("should reject commands with wrong username", func() {
+				wrongReq := ipmiReq("power", "status")
+				wrongReq.Username = "baduser"
+				_, stderr, err := runIPMIInCluster(ctx, config, ns, wrongReq)
+				Expect(err).To(HaveOccurred(), "IPMI command with wrong username should be rejected")
+				Expect(stderr).To(And(
+					ContainSubstring("Get Session Challenge command failed"),
+					ContainSubstring("Unable to establish IPMI v1.5 / RMCP session"),
+				))
+			})
+
+		})
+
 		Context("Power management", func() {
 			It("should report power status", func() {
-				out, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
+				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Chassis Power is on"),
@@ -106,19 +137,19 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should accept power off (graceful) and VM is actually off", func() {
-				_, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
+				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 			})
 
 			It("should accept power on and VM is actually running", func() {
-				_, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIRunning(ctx, k8sClient, ns)
 			})
 
 			It("should accept power cycle and VM is stopped then started again", func() {
-				_, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "cycle"))
+				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "cycle"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIPowerCycle(ctx, k8sClient, ns)
 			})
@@ -126,7 +157,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 		Context("Boot device configuration", func() {
 			It("should set boot device to PXE", func() {
-				out, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
+				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Set Boot Device"),
@@ -136,7 +167,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should set boot device to disk", func() {
-				out, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk"))
+				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Set Boot Device"),
@@ -146,7 +177,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should set boot device to cdrom", func() {
-				out, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom"))
+				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Set Boot Device"),
@@ -163,6 +194,36 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				out, err := runCurlRedfish(ctx, config, ns, redfishBasic("GET", "/Systems/1", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring(`"@odata.id":"/redfish/v1/Systems/1"`))
+			})
+
+			It("should reject access with wrong password", func() {
+				out, err := runCurlRedfish(ctx, config, ns, RedfishRequest{
+					BaseURL:  env.RedfishBaseURL,
+					Method:   "GET",
+					Path:     "/Systems/1",
+					Username: env.Username,
+					Password: "wrongpass",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(And(
+					ContainSubstring("401"),
+					ContainSubstring("Unauthorized"),
+				))
+			})
+
+			It("should reject access with wrong username", func() {
+				out, err := runCurlRedfish(ctx, config, ns, RedfishRequest{
+					BaseURL:  env.RedfishBaseURL,
+					Method:   "GET",
+					Path:     "/Systems/1",
+					Username: "baduser",
+					Password: env.Password,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(And(
+					ContainSubstring("401"),
+					ContainSubstring("Unauthorized"),
+				))
 			})
 		})
 


### PR DESCRIPTION
The current IPMI implementation does not support password verification, and passwords configured in the secret take no effect. This MR adds the verification logic. The protocol interaction part was developed largely with AI coding tools.

fix https://github.com/kubevirtbmc/kubevirtbmc/issues/195