### PR TITLE
fix: sanitize TAG for Docker image tag compatibility in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ ifneq ($(shell git status --porcelain --untracked-files=no),)
 DIRTY := -dirty
 endif
 VERSION := $(VERSION)$(DIRTY)
-# Export the tag to be used in the e2e tests
-export TAG = $(VERSION)
+# Sanitize for Docker image tag: replace chars not in [a-zA-Z0-9_.-] with '-'
+export TAG = $(shell echo "$(VERSION)" | sed 's|[^a-zA-Z0-9_.-]|-|g')
 
 REPO ?= starbops
 


### PR DESCRIPTION
Git branch names with characters like '/' are invalid in Docker image tags. Replace all characters outside [a-zA-Z0-9_.-] with '-' when deriving TAG from VERSION, so kind load docker-image succeeds on any branch name.