### PR TITLE
test: resolve kind binary from project-local ./bin/ first

### DIFF
--- a/test/util/kind.go
+++ b/test/util/kind.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 func LoadImageToKindClusterWithName(names ...string) error {
@@ -12,10 +13,20 @@ func LoadImageToKindClusterWithName(names ...string) error {
 		cluster = v
 	}
 	kindOptions := append([]string{"load", "docker-image", "--name", cluster}, names...)
-	cmd := exec.Command("kind", kindOptions...)
+	cmd := exec.Command(resolveKindBinary(), kindOptions...)
 	out, err := Run(cmd)
 	if err != nil {
 		return fmt.Errorf("kind load docker-image failed: %w\noutput: %s", err, out)
 	}
 	return nil
+}
+
+func resolveKindBinary() string {
+	if projectDir, err := getProjectDir(); err == nil {
+		local := filepath.Join(projectDir, "bin", "kind")
+		if _, err := os.Stat(local); err == nil {
+			return local
+		}
+	}
+	return "kind"
 }


### PR DESCRIPTION
Prefer `./bin/kind` installed by `make kind` over whatever is on $PATH. Falls back to the bare name if the local binary is absent, preserving behaviour for environments that haven't run `make kind` yet.