### PR TITLE
Use KubeVirt start, stop, and restart subresources so Redfish reset actions can distinguish graceful and force operations.

### DIFF
--- a/pkg/generated/redfish/server/model_computer_system_v1_22_0_reset.go
+++ b/pkg/generated/redfish/server/model_computer_system_v1_22_0_reset.go
@@ -18,6 +18,9 @@ type ComputerSystemV1220Reset struct {
 
 	// Friendly action name
 	Title string `json:"title,omitempty"`
+
+	// Supported reset types for this action
+	ResetTypeRedfishAllowableValues []ResourceResetType `json:"ResetType@Redfish.AllowableValues,omitempty"`
 }
 
 // AssertComputerSystemV1220ResetRequired checks if the required fields are not zero-ed

--- a/pkg/redfish/handler.go
+++ b/pkg/redfish/handler.go
@@ -234,9 +234,9 @@ func (h *handler) ComputerSystemReset(resetType server.ResourceResetType) error 
 	powerActionMap := map[server.ResourceResetType]func() error{
 		server.RESOURCERESETTYPE_ON:                h.rm.PowerOn,
 		server.RESOURCERESETTYPE_GRACEFUL_SHUTDOWN: h.rm.PowerOff,
-		server.RESOURCERESETTYPE_FORCE_OFF:         h.rm.PowerOff,
+		server.RESOURCERESETTYPE_FORCE_OFF:         h.rm.ForcePowerOff,
 		server.RESOURCERESETTYPE_GRACEFUL_RESTART:  h.rm.PowerCycle,
-		server.RESOURCERESETTYPE_FORCE_RESTART:     h.rm.PowerCycle,
+		server.RESOURCERESETTYPE_FORCE_RESTART:     h.rm.ForcePowerCycle,
 	}
 
 	powerAction, ok := powerActionMap[resetType]

--- a/pkg/redfish/handler_test.go
+++ b/pkg/redfish/handler_test.go
@@ -319,6 +319,14 @@ func TestComputerSystemReset(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:      "force off reset",
+			resetType: server.RESOURCERESETTYPE_FORCE_OFF,
+			mockSetup: func() {
+				mockRM.EXPECT().ForcePowerOff().Return(nil)
+			},
+			expectedError: false,
+		},
+		{
 			name:      "graceful restart reset",
 			resetType: server.RESOURCERESETTYPE_GRACEFUL_RESTART,
 			mockSetup: func() {
@@ -330,7 +338,7 @@ func TestComputerSystemReset(t *testing.T) {
 			name:      "force restart reset",
 			resetType: server.RESOURCERESETTYPE_FORCE_RESTART,
 			mockSetup: func() {
-				mockRM.EXPECT().PowerCycle().Return(nil)
+				mockRM.EXPECT().ForcePowerCycle().Return(nil)
 			},
 			expectedError: false,
 		},

--- a/pkg/resourcemanager/computersystem_resource.go
+++ b/pkg/resourcemanager/computersystem_resource.go
@@ -44,6 +44,13 @@ func NewComputerSystem(id, name string, powerState server.ResourcePowerState) *C
 			ComputerSystemReset: server.ComputerSystemV1220Reset{
 				Target: fmt.Sprintf("/redfish/v1/Systems/%s/Actions/ComputerSystem.Reset", id),
 				Title:  "Reset",
+				ResetTypeRedfishAllowableValues: []server.ResourceResetType{
+					server.RESOURCERESETTYPE_ON,
+					server.RESOURCERESETTYPE_FORCE_OFF,
+					server.RESOURCERESETTYPE_GRACEFUL_SHUTDOWN,
+					server.RESOURCERESETTYPE_GRACEFUL_RESTART,
+					server.RESOURCERESETTYPE_FORCE_RESTART,
+				},
 			},
 		},
 		Boot: server.ComputerSystemV1220Boot{

--- a/pkg/resourcemanager/computersystem_resource_test.go
+++ b/pkg/resourcemanager/computersystem_resource_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewComputerSystemAdvertisesResetAllowableValues(t *testing.T) {
 	computerSystem := NewComputerSystem("1", "test-namespace/test-vm", server.RESOURCEPOWERSTATE_OFF).ComputerSystem()
 
-	require.Equal(t, []server.ResourceResetType{
+	require.ElementsMatch(t, []server.ResourceResetType{
 		server.RESOURCERESETTYPE_ON,
 		server.RESOURCERESETTYPE_FORCE_OFF,
 		server.RESOURCERESETTYPE_GRACEFUL_SHUTDOWN,

--- a/pkg/resourcemanager/computersystem_resource_test.go
+++ b/pkg/resourcemanager/computersystem_resource_test.go
@@ -1,0 +1,20 @@
+package resourcemanager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"kubevirt.io/kubevirtbmc/pkg/generated/redfish/server"
+)
+
+func TestNewComputerSystemAdvertisesResetAllowableValues(t *testing.T) {
+	computerSystem := NewComputerSystem("1", "test-namespace/test-vm", server.RESOURCEPOWERSTATE_OFF).ComputerSystem()
+
+	require.Equal(t, []server.ResourceResetType{
+		server.RESOURCERESETTYPE_ON,
+		server.RESOURCERESETTYPE_FORCE_OFF,
+		server.RESOURCERESETTYPE_GRACEFUL_SHUTDOWN,
+		server.RESOURCERESETTYPE_GRACEFUL_RESTART,
+		server.RESOURCERESETTYPE_FORCE_RESTART,
+	}, computerSystem.Actions.ComputerSystemReset.ResetTypeRedfishAllowableValues)
+}

--- a/pkg/resourcemanager/mock_resourcemanager.go
+++ b/pkg/resourcemanager/mock_resourcemanager.go
@@ -127,6 +127,34 @@ func (mr *MockResourceManagerMockRecorder) InsertMedia(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertMedia", reflect.TypeOf((*MockResourceManager)(nil).InsertMedia), arg0)
 }
 
+// ForcePowerOff mocks base method.
+func (m *MockResourceManager) ForcePowerOff() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForcePowerOff")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForcePowerOff indicates an expected call of ForcePowerOff.
+func (mr *MockResourceManagerMockRecorder) ForcePowerOff() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForcePowerOff", reflect.TypeOf((*MockResourceManager)(nil).ForcePowerOff))
+}
+
+// ForcePowerCycle mocks base method.
+func (m *MockResourceManager) ForcePowerCycle() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForcePowerCycle")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForcePowerCycle indicates an expected call of ForcePowerCycle.
+func (mr *MockResourceManagerMockRecorder) ForcePowerCycle() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForcePowerCycle", reflect.TypeOf((*MockResourceManager)(nil).ForcePowerCycle))
+}
+
 // PowerCycle mocks base method.
 func (m *MockResourceManager) PowerCycle() error {
 	m.ctrl.T.Helper()

--- a/pkg/resourcemanager/resourcemanager.go
+++ b/pkg/resourcemanager/resourcemanager.go
@@ -18,6 +18,8 @@ type ResourceManager interface {
 	GetPowerStatus() (bool, error)
 	PowerOn() error
 	PowerOff() error
+	ForcePowerOff() error
 	PowerCycle() error
+	ForcePowerCycle() error
 	SetBootDevice(BootDevice) error
 }

--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiclient "kubevirt.io/client-go/containerizeddataimporter"
 	kvclient "kubevirt.io/client-go/kubevirt"
@@ -281,11 +282,10 @@ func (m *VirtualMachineResourceManager) PowerOff() error {
 }
 
 func (m *VirtualMachineResourceManager) ForcePowerOff() error {
-	gracePeriod := int64(0)
 	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).Stop(
 		m.ctx,
 		m.name,
-		&kubevirtv1.StopOptions{GracePeriod: &gracePeriod},
+		&kubevirtv1.StopOptions{GracePeriod: ptr.To[int64](0)},
 	)
 }
 
@@ -310,11 +310,10 @@ func (m *VirtualMachineResourceManager) ForcePowerCycle() error {
 		return m.PowerOn()
 	}
 
-	gracePeriodSeconds := int64(0)
 	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).Restart(
 		m.ctx,
 		m.name,
-		&kubevirtv1.RestartOptions{GracePeriodSeconds: &gracePeriodSeconds},
+		&kubevirtv1.RestartOptions{GracePeriodSeconds: ptr.To[int64](0)},
 	)
 }
 

--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -280,6 +280,15 @@ func (m *VirtualMachineResourceManager) PowerOff() error {
 		Stop(m.ctx, m.name, &kubevirtv1.StopOptions{})
 }
 
+func (m *VirtualMachineResourceManager) ForcePowerOff() error {
+	gracePeriod := int64(0)
+	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).Stop(
+		m.ctx,
+		m.name,
+		&kubevirtv1.StopOptions{GracePeriod: &gracePeriod},
+	)
+}
+
 func (m *VirtualMachineResourceManager) PowerCycle() error {
 	isUp, err := m.GetPowerStatus()
 	if err != nil {
@@ -290,6 +299,23 @@ func (m *VirtualMachineResourceManager) PowerCycle() error {
 	}
 	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).
 		Restart(m.ctx, m.name, &kubevirtv1.RestartOptions{})
+}
+
+func (m *VirtualMachineResourceManager) ForcePowerCycle() error {
+	isUp, err := m.GetPowerStatus()
+	if err != nil {
+		return err
+	}
+	if !isUp {
+		return m.PowerOn()
+	}
+
+	gracePeriodSeconds := int64(0)
+	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).Restart(
+		m.ctx,
+		m.name,
+		&kubevirtv1.RestartOptions{GracePeriodSeconds: &gracePeriodSeconds},
+	)
 }
 
 func (m *VirtualMachineResourceManager) SetBootDevice(bootDevice BootDevice) error {

--- a/pkg/resourcemanager/virtualmachine_resourcemanager.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager.go
@@ -282,6 +282,14 @@ func (m *VirtualMachineResourceManager) PowerOff() error {
 }
 
 func (m *VirtualMachineResourceManager) ForcePowerOff() error {
+	_, err := m.virtClient.KubevirtV1().VirtualMachineInstances(m.namespace).
+		Get(m.ctx, m.name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get VMI %s/%s: %w", m.namespace, m.name, err)
+	}
 	return m.virtClient.KubevirtV1().VirtualMachines(m.namespace).Stop(
 		m.ctx,
 		m.name,

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stesting "k8s.io/client-go/testing"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdifake "kubevirt.io/client-go/containerizeddataimporter/fake"
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
@@ -52,6 +53,45 @@ func (f *fakeVirtualMedia) SetVirtualMedia(imageURL string, inserted bool) {
 	f.called = true
 	f.imageURL = imageURL
 	f.inserted = inserted
+}
+
+func findPutSubresourceAction(actions []k8stesting.Action, subresource string) (k8stesting.Action, bool) {
+	for _, action := range actions {
+		if action.GetVerb() == "put" && action.GetSubresource() == subresource {
+			return action, true
+		}
+	}
+
+	return nil, false
+}
+
+func requirePutSubresourceAction(t *testing.T, actions []k8stesting.Action, subresource string) k8stesting.Action {
+	t.Helper()
+
+	action, ok := findPutSubresourceAction(actions, subresource)
+	if ok {
+		return action
+	}
+
+	require.Failf(t, "expected PUT subresource action", "subresource %q not found", subresource)
+	return nil
+}
+
+func requirePutActionOptions[T any](t *testing.T, action k8stesting.Action, subresource string) *T {
+	t.Helper()
+
+	putAction, ok := action.(kubevirttesting.PutAction[*T])
+	var expectedOptions *T
+	require.Truef(
+		t,
+		ok,
+		"expected PUT %q action to have options type %T, got action type %T",
+		subresource,
+		expectedOptions,
+		action,
+	)
+
+	return putAction.GetOptions()
 }
 
 func TestVirtualMachineResourceManager_EjectMedia(t *testing.T) {
@@ -521,12 +561,8 @@ func TestVirtualMachineResourceManager_PowerOn(t *testing.T) {
 			require.NoError(t, err)
 
 			var startOptions *kubevirtv1.StartOptions
-			for _, action := range fakeVirtClient.Actions() {
-				if action.GetVerb() == "put" && action.GetSubresource() == "start" {
-					startAction, ok := action.(kubevirttesting.PutAction[*kubevirtv1.StartOptions])
-					require.True(t, ok)
-					startOptions = startAction.GetOptions()
-				}
+			if startAction, ok := findPutSubresourceAction(fakeVirtClient.Actions(), "start"); ok {
+				startOptions = requirePutActionOptions[kubevirtv1.StartOptions](t, startAction, "start")
 			}
 
 			if tc.expectStart {
@@ -610,10 +646,9 @@ func TestVirtualMachineResourceManager_ForcePowerOff(t *testing.T) {
 	require.Equal(t, "put", actions[0].GetVerb())
 	require.Equal(t, "stop", actions[0].GetSubresource())
 
-	stopAction, ok := actions[0].(kubevirttesting.PutAction[*kubevirtv1.StopOptions])
-	require.True(t, ok)
-	require.NotNil(t, stopAction.GetOptions().GracePeriod)
-	require.Zero(t, *stopAction.GetOptions().GracePeriod)
+	stopOptions := requirePutActionOptions[kubevirtv1.StopOptions](t, actions[0], "stop")
+	require.NotNil(t, stopOptions.GracePeriod)
+	require.Zero(t, *stopOptions.GracePeriod)
 }
 
 func TestVirtualMachineResourceManager_PowerCycle(t *testing.T) {
@@ -659,15 +694,11 @@ func TestVirtualMachineResourceManager_PowerCycle(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			actions := fakeVirtClient.Actions()
-			require.NotEmpty(t, actions)
-			lastAction := actions[len(actions)-1]
-			require.Equal(t, "put", lastAction.GetVerb())
+			expectedSubresource := "start"
 			if tc.vmi != nil {
-				require.Equal(t, "restart", lastAction.GetSubresource())
-			} else {
-				require.Equal(t, "start", lastAction.GetSubresource())
+				expectedSubresource = "restart"
 			}
+			requirePutSubresourceAction(t, fakeVirtClient.Actions(), expectedSubresource)
 		})
 	}
 }
@@ -676,11 +707,13 @@ func TestVirtualMachineResourceManager_ForcePowerCycle(t *testing.T) {
 	testCases := []struct {
 		name                string
 		vm                  *kubevirtv1.VirtualMachine
+		vmi                 *kubevirtv1.VirtualMachineInstance
 		expectedSubresource string
 	}{
 		{
 			name:                "Force power cycle a running virtual machine should trigger immediate VM restart",
 			vm:                  builder.NewVirtualMachineBuilder(testNamespace, testVMName).Ready(true).Build(),
+			vmi:                 builder.NewVirtualMachineInstanceBuilder(testNamespace, testVMName).Build(),
 			expectedSubresource: "restart",
 		},
 		{
@@ -693,6 +726,10 @@ func TestVirtualMachineResourceManager_ForcePowerCycle(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeVirtClient := kubevirtfake.NewSimpleClientset(tc.vm)
+			if tc.vmi != nil {
+				err := fakeVirtClient.Tracker().Add(tc.vmi)
+				require.NoError(t, err, "Mock resource should add into fake client tracker")
+			}
 
 			vmrm := &VirtualMachineResourceManager{
 				ctx:        context.TODO(),
@@ -704,17 +741,12 @@ func TestVirtualMachineResourceManager_ForcePowerCycle(t *testing.T) {
 			err := vmrm.ForcePowerCycle()
 			require.NoError(t, err)
 
-			actions := fakeVirtClient.Actions()
-			require.NotEmpty(t, actions)
-			lastAction := actions[len(actions)-1]
-			require.Equal(t, "put", lastAction.GetVerb())
-			require.Equal(t, tc.expectedSubresource, lastAction.GetSubresource())
+			powerAction := requirePutSubresourceAction(t, fakeVirtClient.Actions(), tc.expectedSubresource)
 
 			if tc.expectedSubresource == "restart" {
-				restartAction, ok := lastAction.(kubevirttesting.PutAction[*kubevirtv1.RestartOptions])
-				require.True(t, ok)
-				require.NotNil(t, restartAction.GetOptions().GracePeriodSeconds)
-				require.Zero(t, *restartAction.GetOptions().GracePeriodSeconds)
+				restartOptions := requirePutActionOptions[kubevirtv1.RestartOptions](t, powerAction, "restart")
+				require.NotNil(t, restartOptions.GracePeriodSeconds)
+				require.Zero(t, *restartOptions.GracePeriodSeconds)
 			}
 		})
 	}

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -12,6 +12,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdifake "kubevirt.io/client-go/containerizeddataimporter/fake"
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
+	kubevirttesting "kubevirt.io/client-go/testing"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirtbmc/pkg/builder"
@@ -463,28 +464,36 @@ func TestVirtualMachineResourceManager_PowerOn(t *testing.T) {
 	testCases := []struct {
 		name        string
 		vm          *kubevirtv1.VirtualMachine
+		vmi         *kubevirtv1.VirtualMachineInstance
+		expectStart bool
 		shouldError bool
 	}{
 		{
 			name:        "Power on a virtual machine that should be on should have no effect",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(true).Build(),
+			vmi:         builder.NewVirtualMachineInstanceBuilder(testNamespace, testVMName).Build(),
+			expectStart: false,
 			shouldError: false,
 		},
 		{
 			name:        "Power on a virtual machine that should be off should succeed",
 			vm:          builder.NewVirtualMachineBuilder(testNamespace, testVMName).Running(false).Build(),
+			expectStart: true,
 			shouldError: false,
 		},
 		{
 			name: "Power on a virtual machine whose RunStrategy is set to RerunOnFailure should have no effect",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				RunStrategy(kubevirtv1.RunStrategyRerunOnFailure).Build(),
+			vmi:         builder.NewVirtualMachineInstanceBuilder(testNamespace, testVMName).Build(),
+			expectStart: false,
 			shouldError: false,
 		},
 		{
 			name: "Power on a virtual machine whose RunStrategy is set to Halted should succeed",
 			vm: builder.NewVirtualMachineBuilder(testNamespace, testVMName).
 				RunStrategy(kubevirtv1.RunStrategyHalted).Build(),
+			expectStart: true,
 			shouldError: false,
 		},
 	}
@@ -492,6 +501,10 @@ func TestVirtualMachineResourceManager_PowerOn(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeVirtClient := kubevirtfake.NewSimpleClientset(tc.vm)
+			if tc.vmi != nil {
+				err := fakeVirtClient.Tracker().Add(tc.vmi)
+				require.NoError(t, err, "Mock resource should add into fake client tracker")
+			}
 
 			vmrm := &VirtualMachineResourceManager{
 				ctx:        context.TODO(),
@@ -506,6 +519,22 @@ func TestVirtualMachineResourceManager_PowerOn(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+
+			var startOptions *kubevirtv1.StartOptions
+			for _, action := range fakeVirtClient.Actions() {
+				if action.GetVerb() == "put" && action.GetSubresource() == "start" {
+					startAction, ok := action.(kubevirttesting.PutAction[*kubevirtv1.StartOptions])
+					require.True(t, ok)
+					startOptions = startAction.GetOptions()
+				}
+			}
+
+			if tc.expectStart {
+				require.NotNil(t, startOptions)
+				require.False(t, startOptions.Paused)
+			} else {
+				require.Nil(t, startOptions)
+			}
 		})
 	}
 }
@@ -561,6 +590,32 @@ func TestVirtualMachineResourceManager_PowerOff(t *testing.T) {
 	}
 }
 
+func TestVirtualMachineResourceManager_ForcePowerOff(t *testing.T) {
+	fakeVirtClient := kubevirtfake.NewSimpleClientset(
+		builder.NewVirtualMachineBuilder(testNamespace, testVMName).Ready(true).Build(),
+	)
+
+	vmrm := &VirtualMachineResourceManager{
+		ctx:        context.TODO(),
+		virtClient: fakeVirtClient,
+		namespace:  testNamespace,
+		name:       testVMName,
+	}
+
+	err := vmrm.ForcePowerOff()
+	require.NoError(t, err)
+
+	actions := fakeVirtClient.Actions()
+	require.Len(t, actions, 1)
+	require.Equal(t, "put", actions[0].GetVerb())
+	require.Equal(t, "stop", actions[0].GetSubresource())
+
+	stopAction, ok := actions[0].(kubevirttesting.PutAction[*kubevirtv1.StopOptions])
+	require.True(t, ok)
+	require.NotNil(t, stopAction.GetOptions().GracePeriod)
+	require.Zero(t, *stopAction.GetOptions().GracePeriod)
+}
+
 func TestVirtualMachineResourceManager_PowerCycle(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -603,6 +658,64 @@ func TestVirtualMachineResourceManager_PowerCycle(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+
+			actions := fakeVirtClient.Actions()
+			require.NotEmpty(t, actions)
+			lastAction := actions[len(actions)-1]
+			require.Equal(t, "put", lastAction.GetVerb())
+			if tc.vmi != nil {
+				require.Equal(t, "restart", lastAction.GetSubresource())
+			} else {
+				require.Equal(t, "start", lastAction.GetSubresource())
+			}
+		})
+	}
+}
+
+func TestVirtualMachineResourceManager_ForcePowerCycle(t *testing.T) {
+	testCases := []struct {
+		name                string
+		vm                  *kubevirtv1.VirtualMachine
+		expectedSubresource string
+	}{
+		{
+			name:                "Force power cycle a running virtual machine should trigger immediate VM restart",
+			vm:                  builder.NewVirtualMachineBuilder(testNamespace, testVMName).Ready(true).Build(),
+			expectedSubresource: "restart",
+		},
+		{
+			name:                "Force power cycle a halted virtual machine should trigger VM start",
+			vm:                  builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
+			expectedSubresource: "start",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeVirtClient := kubevirtfake.NewSimpleClientset(tc.vm)
+
+			vmrm := &VirtualMachineResourceManager{
+				ctx:        context.TODO(),
+				virtClient: fakeVirtClient,
+				namespace:  testNamespace,
+				name:       testVMName,
+			}
+
+			err := vmrm.ForcePowerCycle()
+			require.NoError(t, err)
+
+			actions := fakeVirtClient.Actions()
+			require.NotEmpty(t, actions)
+			lastAction := actions[len(actions)-1]
+			require.Equal(t, "put", lastAction.GetVerb())
+			require.Equal(t, tc.expectedSubresource, lastAction.GetSubresource())
+
+			if tc.expectedSubresource == "restart" {
+				restartAction, ok := lastAction.(kubevirttesting.PutAction[*kubevirtv1.RestartOptions])
+				require.True(t, ok)
+				require.NotNil(t, restartAction.GetOptions().GracePeriodSeconds)
+				require.Zero(t, *restartAction.GetOptions().GracePeriodSeconds)
+			}
 		})
 	}
 }

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -630,6 +630,8 @@ func TestVirtualMachineResourceManager_ForcePowerOff(t *testing.T) {
 	fakeVirtClient := kubevirtfake.NewSimpleClientset(
 		builder.NewVirtualMachineBuilder(testNamespace, testVMName).Ready(true).Build(),
 	)
+	err := fakeVirtClient.Tracker().Add(builder.NewVirtualMachineInstanceBuilder(testNamespace, testVMName).Build())
+	require.NoError(t, err, "Mock resource should add into fake client tracker")
 
 	vmrm := &VirtualMachineResourceManager{
 		ctx:        context.TODO(),
@@ -638,15 +640,12 @@ func TestVirtualMachineResourceManager_ForcePowerOff(t *testing.T) {
 		name:       testVMName,
 	}
 
-	err := vmrm.ForcePowerOff()
+	err = vmrm.ForcePowerOff()
 	require.NoError(t, err)
 
-	actions := fakeVirtClient.Actions()
-	require.Len(t, actions, 1)
-	require.Equal(t, "put", actions[0].GetVerb())
-	require.Equal(t, "stop", actions[0].GetSubresource())
+	stopAction := requirePutSubresourceAction(t, fakeVirtClient.Actions(), "stop")
 
-	stopOptions := requirePutActionOptions[kubevirtv1.StopOptions](t, actions[0], "stop")
+	stopOptions := requirePutActionOptions[kubevirtv1.StopOptions](t, stopAction, "stop")
 	require.NotNil(t, stopOptions.GracePeriod)
 	require.Zero(t, *stopOptions.GracePeriod)
 }

--- a/test/virtbmc-agent/agent_test.go
+++ b/test/virtbmc-agent/agent_test.go
@@ -201,6 +201,18 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					ContainSubstring("Off"),
 				))
 			})
+
+			It("should advertise supported reset action values", func() {
+				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring(`"ResetType@Redfish.AllowableValues"`))
+				Expect(out).To(ContainSubstring(`"On"`))
+				Expect(out).To(ContainSubstring(`"ForceOff"`))
+				Expect(out).To(ContainSubstring(`"GracefulShutdown"`))
+				Expect(out).To(ContainSubstring(`"GracefulRestart"`))
+				Expect(out).To(ContainSubstring(`"ForceRestart"`))
+			})
+
 			It("should accept graceful shutdown action and VM is actually off", func() {
 				_, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"GracefulShutdown"}`))
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

Update Redfish reset handling to call KubeVirt start, stop, and restart subresources, including distinct force-off and force-restart paths with zero grace period. Also advertises supported reset types in the ComputerSystem.Reset action and adds coverage for the new power action mappings.

This is a proposal for issue #204 