### PR TITLE
chore: speed up e2e execution time

### DIFF
--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -1,6 +1,11 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    serializeImagePulls: false
+    maxParallelImagePulls: 10
 nodes:
   - role: control-plane
-  - role: worker
   - role: worker

--- a/test/util/e2e_resources.go
+++ b/test/util/e2e_resources.go
@@ -240,12 +240,14 @@ func EnsureTestVMSecretBMC(ctx context.Context, k8sClient client.Client, namespa
 func E2EVM(namespace string) *kubevirtv1.VirtualMachine {
 	runStrategy := kubevirtv1.RunStrategyAlways
 	guestMemory := resource.MustParse("256Mi")
+	terminationGracePeriodSeconds := int64(1)
 	return &kubevirtv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{Name: E2EVMName, Namespace: namespace},
 		Spec: kubevirtv1.VirtualMachineSpec{
 			RunStrategy: &runStrategy,
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					Domain: kubevirtv1.DomainSpec{
 						Memory: &kubevirtv1.Memory{Guest: &guestMemory},
 						Resources: kubevirtv1.ResourceRequirements{
@@ -263,7 +265,10 @@ func E2EVM(namespace string) *kubevirtv1.VirtualMachine {
 					},
 					Volumes: []kubevirtv1.Volume{
 						{Name: "containerdisk", VolumeSource: kubevirtv1.VolumeSource{
-							ContainerDisk: &kubevirtv1.ContainerDiskSource{Image: "quay.io/kubevirt/cirros-container-disk-demo"},
+							ContainerDisk: &kubevirtv1.ContainerDiskSource{
+								Image:           "quay.io/kubevirt/cirros-container-disk-demo",
+								ImagePullPolicy: corev1.PullIfNotPresent,
+							},
 						}},
 						{Name: "cdrom", VolumeSource: kubevirtv1.VolumeSource{
 							EmptyDisk: &kubevirtv1.EmptyDiskSource{Capacity: resource.MustParse("1Gi")},


### PR DESCRIPTION
fix #211

Before 
1 master + 2 workers, total 12m3s
ok  	kubevirt.io/kubevirtbmc/test/virtbmc-controller	298.651s
ok  	kubevirt.io/kubevirtbmc/test/virtbmc-agent	373.960s
https://github.com/kubevirtbmc/kubevirtbmc/actions/runs/27910682457/job/82590029358


Single node, total 7m6s
ok  	kubevirt.io/kubevirtbmc/test/virtbmc-controller	195.282s
ok  	kubevirt.io/kubevirtbmc/test/virtbmc-agent	191.933s
https://github.com/kubevirtbmc/kubevirtbmc/actions/runs/28009668382/job/82899654346


1 master + 1 worker, total 7m54s 
ok  	kubevirt.io/kubevirtbmc/test/virtbmc-controller	236.421s
ok  	kubevirt.io/kubevirtbmc/test/virtbmc-agent	193.977s
https://github.com/kubevirtbmc/kubevirtbmc/actions/runs/28069138506/job/83099818433
