### PR TITLE
chore: migrate container images to kubevirtbmc org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     env:
-      REPO: starbops
+      REPO: kubevirtbmc
       MANAGER: virtbmc-controller
       AGENT: virtbmc
       VERSION: ${{ github.ref_name }}-head

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     env:
-      REPO: starbops
+      REPO: kubevirtbmc
       MANAGER: virtbmc-controller
       AGENT: virtbmc
       VERSION: pr-${{ github.event.number }}-head

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     env:
-      REPO: starbops
+      REPO: kubevirtbmc
       MANAGER: virtbmc-controller
       AGENT: virtbmc
       VERSION: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION := $(VERSION)$(DIRTY)
 # Sanitize for Docker image tag: replace chars not in [a-zA-Z0-9_.-] with '-'
 export TAG = $(shell echo "$(VERSION)" | sed 's|[^a-zA-Z0-9_.-]|-|g')
 
-REPO ?= starbops
+export REPO ?= kubevirtbmc
 
 # Image URL to use all building/pushing image targets
 MGR_IMG ?= $(REPO)/virtbmc-controller:$(TAG)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: starbops/virtbmc-controller
+  newName: kubevirtbmc/virtbmc-controller
   newTag: dev

--- a/deploy/charts/kubevirtbmc/values.yaml
+++ b/deploy/charts/kubevirtbmc/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: starbops/virtbmc-controller
+  repository: kubevirtbmc/virtbmc-controller
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -4,7 +4,7 @@ const (
 	DefaultUsername            = "admin"
 	DefaultPassword            = "password"
 	virtBMCContainerName       = "virtbmc"
-	VirtBMCImageName           = "starbops/virtbmc"
+	VirtBMCImageName           = "kubevirtbmc/virtbmc"
 	ipmiPort                   = 10623
 	redfishPort                = 10080
 	IPMISvcPort                = 623

--- a/test/virtbmc-agent/suite_test.go
+++ b/test/virtbmc-agent/suite_test.go
@@ -31,18 +31,20 @@ var (
 	skipCertManagerInstall        = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	isCertManagerAlreadyInstalled = false
 
-	controllerManagerImage = fmt.Sprintf("starbops/virtbmc-controller:%s", func() string {
-		if tag := os.Getenv("TAG"); tag != "" {
-			return tag
+	repo = func() string {
+		if r := os.Getenv("REPO"); r != "" {
+			return r
+		}
+		return "kubevirtbmc"
+	}()
+	tag = func() string {
+		if t := os.Getenv("TAG"); t != "" {
+			return t
 		}
 		return "dev"
-	}())
-	agentImage = fmt.Sprintf("starbops/virtbmc:%s", func() string {
-		if tag := os.Getenv("TAG"); tag != "" {
-			return tag
-		}
-		return "dev"
-	}())
+	}()
+	controllerManagerImage = fmt.Sprintf("%s/virtbmc-controller:%s", repo, tag)
+	agentImage             = fmt.Sprintf("%s/virtbmc:%s", repo, tag)
 
 	config    *rest.Config
 	k8sClient client.Client

--- a/test/virtbmc-controller/suite_test.go
+++ b/test/virtbmc-controller/suite_test.go
@@ -36,18 +36,20 @@ var (
 	skipCertManagerInstall        = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	isCertManagerAlreadyInstalled = false
 
-	controllerManagerImage = fmt.Sprintf("starbops/virtbmc-controller:%s", func() string {
-		if tag := os.Getenv("TAG"); tag != "" {
-			return tag
+	repo = func() string {
+		if r := os.Getenv("REPO"); r != "" {
+			return r
+		}
+		return "kubevirtbmc"
+	}()
+	tag = func() string {
+		if t := os.Getenv("TAG"); t != "" {
+			return t
 		}
 		return "dev"
-	}())
-	agentImage = fmt.Sprintf("starbops/virtbmc:%s", func() string {
-		if tag := os.Getenv("TAG"); tag != "" {
-			return tag
-		}
-		return "dev"
-	}())
+	}()
+	controllerManagerImage = fmt.Sprintf("%s/virtbmc-controller:%s", repo, tag)
+	agentImage             = fmt.Sprintf("%s/virtbmc:%s", repo, tag)
 
 	config    *rest.Config
 	k8sClient client.Client


### PR DESCRIPTION
Move the built container images to the `kubevirtbmc` organization. This PR also involves chart changes so will need to bump the chart version in a follow-up PR.

Related issue: #216