### PR TITLE
fix(ipmi): map chassis control commands to correct power methods

### DIFF
--- a/pkg/ipmi/handler.go
+++ b/pkg/ipmi/handler.go
@@ -26,15 +26,25 @@ func (h *handler) chassisControlHandler(m *goipmi.Message) goipmi.Response {
 	var err error
 
 	switch r.ChassisControl {
-	case goipmi.ControlPowerDown, goipmi.ControlPowerAcpiSoft:
+	case goipmi.ControlPowerDown:
+		// Immediate power down (no OS notification), per IPMI spec §28.3.
+		logrus.Info("force power off")
+		err = h.rm.ForcePowerOff()
+	case goipmi.ControlPowerAcpiSoft:
+		// ACPI graceful shutdown, per IPMI spec §28.3.
 		logrus.Info("power off")
 		err = h.rm.PowerOff()
 	case goipmi.ControlPowerUp:
 		logrus.Info("power on")
 		err = h.rm.PowerOn()
-	case goipmi.ControlPowerCycle, goipmi.ControlPowerHardReset:
+	case goipmi.ControlPowerCycle:
+		// Graceful power cycle (OS-level), per IPMI spec §28.3.
 		logrus.Info("power cycle")
 		err = h.rm.PowerCycle()
+	case goipmi.ControlPowerHardReset:
+		// Hard reset (asserts system reset without power cycling), per IPMI spec §28.3.
+		logrus.Info("force power cycle")
+		err = h.rm.ForcePowerCycle()
 	}
 
 	if err != nil {

--- a/pkg/ipmi/handler_test.go
+++ b/pkg/ipmi/handler_test.go
@@ -41,16 +41,32 @@ func TestChassisControlHandler(t *testing.T) {
 			expectedCode: goipmi.ErrInvalidState,
 		},
 		{
-			name:           "PowerOff success",
+			name:           "ForcePowerOff success",
 			chassisControl: goipmi.ControlPowerDown,
+			expectedCall: func() {
+				mockRM.EXPECT().ForcePowerOff().Return(nil)
+			},
+			expectedCode: goipmi.CommandCompleted,
+		},
+		{
+			name:           "ForcePowerOff failure",
+			chassisControl: goipmi.ControlPowerDown,
+			expectedCall: func() {
+				mockRM.EXPECT().ForcePowerOff().Return(fmt.Errorf("error"))
+			},
+			expectedCode: goipmi.ErrInvalidState,
+		},
+		{
+			name:           "PowerOff (ACPI soft) success",
+			chassisControl: goipmi.ControlPowerAcpiSoft,
 			expectedCall: func() {
 				mockRM.EXPECT().PowerOff().Return(nil)
 			},
 			expectedCode: goipmi.CommandCompleted,
 		},
 		{
-			name:           "PowerOff failure",
-			chassisControl: goipmi.ControlPowerDown,
+			name:           "PowerOff (ACPI soft) failure",
+			chassisControl: goipmi.ControlPowerAcpiSoft,
 			expectedCall: func() {
 				mockRM.EXPECT().PowerOff().Return(fmt.Errorf("error"))
 			},
@@ -69,6 +85,22 @@ func TestChassisControlHandler(t *testing.T) {
 			chassisControl: goipmi.ControlPowerCycle,
 			expectedCall: func() {
 				mockRM.EXPECT().PowerCycle().Return(fmt.Errorf("error"))
+			},
+			expectedCode: goipmi.ErrInvalidState,
+		},
+		{
+			name:           "ForcePowerCycle success",
+			chassisControl: goipmi.ControlPowerHardReset,
+			expectedCall: func() {
+				mockRM.EXPECT().ForcePowerCycle().Return(nil)
+			},
+			expectedCode: goipmi.CommandCompleted,
+		},
+		{
+			name:           "ForcePowerCycle failure",
+			chassisControl: goipmi.ControlPowerHardReset,
+			expectedCall: func() {
+				mockRM.EXPECT().ForcePowerCycle().Return(fmt.Errorf("error"))
 			},
 			expectedCode: goipmi.ErrInvalidState,
 		},

--- a/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
+++ b/pkg/resourcemanager/virtualmachine_resourcemanager_test.go
@@ -627,27 +627,50 @@ func TestVirtualMachineResourceManager_PowerOff(t *testing.T) {
 }
 
 func TestVirtualMachineResourceManager_ForcePowerOff(t *testing.T) {
-	fakeVirtClient := kubevirtfake.NewSimpleClientset(
-		builder.NewVirtualMachineBuilder(testNamespace, testVMName).Ready(true).Build(),
-	)
-	err := fakeVirtClient.Tracker().Add(builder.NewVirtualMachineInstanceBuilder(testNamespace, testVMName).Build())
-	require.NoError(t, err, "Mock resource should add into fake client tracker")
-
-	vmrm := &VirtualMachineResourceManager{
-		ctx:        context.TODO(),
-		virtClient: fakeVirtClient,
-		namespace:  testNamespace,
-		name:       testVMName,
+	testCases := []struct {
+		name       string
+		vm         *kubevirtv1.VirtualMachine
+		vmi        *kubevirtv1.VirtualMachineInstance
+		expectStop bool
+	}{
+		{
+			name:       "Force power off a running virtual machine should trigger immediate VM stop",
+			vm:         builder.NewVirtualMachineBuilder(testNamespace, testVMName).Ready(true).Build(),
+			vmi:        builder.NewVirtualMachineInstanceBuilder(testNamespace, testVMName).Build(),
+			expectStop: true,
+		},
+		{
+			name:       "Force power off a halted virtual machine should be a no-op",
+			vm:         builder.NewVirtualMachineBuilder(testNamespace, testVMName).Build(),
+			expectStop: false,
+		},
 	}
-
-	err = vmrm.ForcePowerOff()
-	require.NoError(t, err)
-
-	stopAction := requirePutSubresourceAction(t, fakeVirtClient.Actions(), "stop")
-
-	stopOptions := requirePutActionOptions[kubevirtv1.StopOptions](t, stopAction, "stop")
-	require.NotNil(t, stopOptions.GracePeriod)
-	require.Zero(t, *stopOptions.GracePeriod)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeVirtClient := kubevirtfake.NewSimpleClientset(tc.vm)
+			if tc.vmi != nil {
+				err := fakeVirtClient.Tracker().Add(tc.vmi)
+				require.NoError(t, err, "Mock resource should add into fake client tracker")
+			}
+			vmrm := &VirtualMachineResourceManager{
+				ctx:        context.TODO(),
+				virtClient: fakeVirtClient,
+				namespace:  testNamespace,
+				name:       testVMName,
+			}
+			err := vmrm.ForcePowerOff()
+			require.NoError(t, err)
+			stopAction, ok := findPutSubresourceAction(fakeVirtClient.Actions(), "stop")
+			if tc.expectStop {
+				require.True(t, ok)
+				stopOptions := requirePutActionOptions[kubevirtv1.StopOptions](t, stopAction, "stop")
+				require.NotNil(t, stopOptions.GracePeriod)
+				require.Zero(t, *stopOptions.GracePeriod)
+			} else {
+				require.False(t, ok)
+			}
+		})
+	}
 }
 
 func TestVirtualMachineResourceManager_PowerCycle(t *testing.T) {

--- a/test/virtbmc-agent/agent_test.go
+++ b/test/virtbmc-agent/agent_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				))
 			})
 
-			It("should accept power off (graceful) and VM is actually off", func() {
+			It("should accept power off and VM is actually off", func() {
 				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
@@ -150,6 +150,24 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should accept power cycle and VM is stopped then started again", func() {
 				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "cycle"))
+				Expect(err).NotTo(HaveOccurred())
+				waitForVMIPowerCycle(ctx, k8sClient, ns)
+			})
+
+			It("should accept power soft (graceful ACPI shutdown) and VM is actually off", func() {
+				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
+				Expect(err).NotTo(HaveOccurred())
+				waitForVMIDeleted(ctx, k8sClient, ns)
+			})
+
+			It("should accept power on and VM is actually running", func() {
+				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				Expect(err).NotTo(HaveOccurred())
+				waitForVMIRunning(ctx, k8sClient, ns)
+			})
+
+			It("should accept power reset (hard reset) and VM is stopped then started again", func() {
+				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "reset"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIPowerCycle(ctx, k8sClient, ns)
 			})


### PR DESCRIPTION
Align IPMI chassis control handler with IPMI spec §28.3 semantics:

- ControlPowerDown (immediate)   → ForcePowerOff()
- ControlPowerAcpiSoft (graceful) → PowerOff()
- ControlPowerCycle (graceful)    → PowerCycle()     (unchanged)
- ControlPowerHardReset (hard)    → ForcePowerCycle()

Previously ControlPowerDown was grouped with ControlPowerAcpiSoft under graceful PowerOff(), and ControlPowerHardReset was grouped with ControlPowerCycle under graceful PowerCycle(). The new Force* methods allow restoring spec-level fidelity.

like https://github.com/kubevirtbmc/kubevirtbmc/issues/204 but for ipmi

fix #223