### PR TITLE
added feature to support additional network on virtbmc pod

### DIFF
--- a/api/bmc/v1beta1/virtualmachinebmc_types.go
+++ b/api/bmc/v1beta1/virtualmachinebmc_types.go
@@ -39,6 +39,10 @@ type VirtualMachineBMCSpec struct {
 	// IPMI configures the IPMI simulator.
 	// +optional
 	IPMI *IPMISpec `json:"ipmi,omitempty"`
+
+	// NetworkRef configures additional multus NAD to the virtualMachineBMC pod.
+	// +optional
+	NetworkRef string `json:"networkRef,omitempty"`
 }
 
 // IPMISpec defines the IPMI-specific configuration.

--- a/config/crd/bases/bmc.kubevirt.io_virtualmachinebmcs.yaml
+++ b/config/crd/bases/bmc.kubevirt.io_virtualmachinebmcs.yaml
@@ -76,6 +76,10 @@ spec:
                     description: Enabled toggles the IPMI simulator.
                     type: boolean
                 type: object
+              networkRef:
+                description: NetworkRef configures additional multus NAD to the virtualMachineBMC
+                  pod.
+                type: string
               virtualMachineRef:
                 description: Reference to the VM to manage.
                 properties:

--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -15,4 +15,5 @@ const (
 	VMNameLabel                = "kubevirt.io/vm-name"
 	VirtualMachineBMCNamespace = "kubevirtbmc-system"
 	EnableIPMIAnnotation       = "bmc.kubevirt.io/enable-ipmi"
+	MultusNetworksAnnotation   = "k8s.v1.cni.cncf.io/networks"
 )

--- a/internal/controller/virtualmachinebmc/controller.go
+++ b/internal/controller/virtualmachinebmc/controller.go
@@ -507,7 +507,7 @@ func podNetworkRef(pod *corev1.Pod) string {
 // reconcileNetworkChange detects a mismatch between the spec's NetworkRef and
 // the annotation stamped on the existing pod. Since pod networking is immutable,
 // the pod must be recreated when the network attachment changes.
-func (r *VirtualMachineBMCReconciler) reconcileNetworkChange(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (requeue bool, err error) {
+func (r *VirtualMachineBMCReconciler) reconcileNetworkChange(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (deleted bool, err error) {
 
 	log := log.FromContext(ctx)
 
@@ -611,7 +611,7 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 	if deleted {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// Prepare the virtBMC Pod

--- a/internal/controller/virtualmachinebmc/controller.go
+++ b/internal/controller/virtualmachinebmc/controller.go
@@ -140,17 +140,23 @@ func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualM
 		secretName = virtualMachineBMC.Spec.AuthSecretRef.Name
 	}
 
+	annotations := map[string]string{
+		EnableIPMIAnnotation: strconv.FormatBool(specIPMIEnabled(&virtualMachineBMC.Spec)),
+	}
+
+	if virtualMachineBMC.Spec.NetworkRef != "" {
+		annotations[MultusNetworksAnnotation] = virtualMachineBMC.Spec.NetworkRef
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
 				VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
 			},
-			Annotations: map[string]string{
-				EnableIPMIAnnotation: strconv.FormatBool(specIPMIEnabled(&virtualMachineBMC.Spec)),
-			},
-			Name:      name,
-			Namespace: virtualMachineBMC.Namespace,
+			Annotations: annotations,
+			Name:        name,
+			Namespace:   virtualMachineBMC.Namespace,
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: serviceAccountName,
@@ -486,6 +492,52 @@ func (r *VirtualMachineBMCReconciler) reconcileIPMIChange(ctx context.Context, v
 	return true, nil
 }
 
+func specNetworkRef(spec *bmcv1.VirtualMachineBMCSpec) string {
+	return spec.NetworkRef
+}
+
+func podNetworkRef(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+
+	return pod.Annotations[MultusNetworksAnnotation]
+}
+
+// reconcileNetworkChange detects a mismatch between the spec's NetworkRef and
+// the annotation stamped on the existing pod. Since pod networking is immutable,
+// the pod must be recreated when the network attachment changes.
+func (r *VirtualMachineBMCReconciler) reconcileNetworkChange(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (requeue bool, err error) {
+
+	log := log.FromContext(ctx)
+
+	pod, err := r.getVirtBMCPod(ctx, virtualMachineBMC)
+	if err != nil {
+		return false, err
+	}
+
+	if pod == nil {
+		return false, nil
+	}
+
+	currentNetworkRef := podNetworkRef(pod)
+	desiredNetworkRef := specNetworkRef(&virtualMachineBMC.Spec)
+
+	if currentNetworkRef == desiredNetworkRef {
+		return false, nil
+	}
+
+	log.Info("networkRef changed, replacing pod",
+		"currentNetworkRef", currentNetworkRef,
+		"desiredNetworkRef", desiredNetworkRef)
+
+	if err := r.deleteVirtBMCPod(ctx, virtualMachineBMC); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 //+kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstances,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups=bmc.kubevirt.io,resources=virtualmachinebmcs,verbs=get;list;watch;create;update;patch;delete
@@ -552,6 +604,14 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if err := r.ensureRBACResources(ctx, &virtualMachineBMC); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	deleted, err = r.reconcileNetworkChange(ctx, &virtualMachineBMC)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if deleted {
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Prepare the virtBMC Pod

--- a/internal/controller/virtualmachinebmc/controller_test.go
+++ b/internal/controller/virtualmachinebmc/controller_test.go
@@ -713,6 +713,152 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(svcPortNames).To(ContainElement(ipmiPortName))
 		})
 
+		It("Should create Pod with multus network annotation when networkRef is set", func() {
+			ctx := context.Background()
+			vmName := "testvm-network-ref"
+			secretName := "secret-network-ref"
+			bmcName := "bmc-network-ref"
+			networkRef := "my-namespace/my-network"
+
+			By("Creating the VirtualMachine and Secret")
+			vm := &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Running: boolPtr(false),
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vm)).Should(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"username": []byte("admin"),
+					"password": []byte("password123"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating a VirtualMachineBMC with networkRef set")
+			virtualMachineBMC := &bmcv1.VirtualMachineBMC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bmcName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Spec: bmcv1.VirtualMachineBMCSpec{
+					VirtualMachineRef: &corev1.LocalObjectReference{Name: vmName},
+					AuthSecretRef:     &corev1.LocalObjectReference{Name: secretName},
+					NetworkRef:        networkRef,
+				},
+			}
+			Expect(k8sClient.Create(ctx, virtualMachineBMC)).To(Succeed())
+
+			By("Checking that the Pod is created with the multus network annotation")
+			podLookupKey := types.NamespacedName{
+				Name:      vmName + "-virtbmc",
+				Namespace: testVirtualMachineBMCNamespace,
+			}
+			createdPod := &corev1.Pod{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, podLookupKey, createdPod)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(createdPod.Annotations).To(HaveKeyWithValue(MultusNetworksAnnotation, networkRef))
+		})
+
+		It("Should delete and recreate Pod when networkRef is changed", func() {
+			ctx := context.Background()
+			vmName := "testvm-network-change"
+			secretName := "secret-network-change"
+			bmcName := "bmc-network-change"
+
+			By("Creating the VirtualMachine and Secret")
+			vm := &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Running: boolPtr(false),
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vm)).Should(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"username": []byte("newadmin"),
+					"password": []byte("newpassword456"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating a VirtualMachineBMC without networkRef")
+			virtualMachineBMC := &bmcv1.VirtualMachineBMC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bmcName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Spec: bmcv1.VirtualMachineBMCSpec{
+					VirtualMachineRef: &corev1.LocalObjectReference{Name: vmName},
+					AuthSecretRef:     &corev1.LocalObjectReference{Name: secretName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, virtualMachineBMC)).To(Succeed())
+
+			By("Waiting for the Pod to be created")
+			podLookupKey := types.NamespacedName{
+				Name:      vmName + "-virtbmc",
+				Namespace: testVirtualMachineBMCNamespace,
+			}
+			var originalPod corev1.Pod
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, podLookupKey, &originalPod)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(originalPod.Annotations).ToNot(HaveKey(MultusNetworksAnnotation))
+			originalPodUID := originalPod.UID
+
+			By("Setting networkRef on the VirtualMachineBMC")
+			bmcLookupKey := types.NamespacedName{Name: bmcName, Namespace: testVirtualMachineBMCNamespace}
+			updatedBMC := &bmcv1.VirtualMachineBMC{}
+			Expect(k8sClient.Get(ctx, bmcLookupKey, updatedBMC)).Should(Succeed())
+			updatedBMC.Spec.NetworkRef = "my-namespace/my-network"
+			Expect(k8sClient.Update(ctx, updatedBMC)).Should(Succeed())
+
+			By("Verifying that a new Pod is created carrying the network annotation")
+			var newPod corev1.Pod
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, podLookupKey, &newPod); err != nil {
+					return false
+				}
+				return newPod.UID != originalPodUID
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(newPod.Annotations).To(HaveKeyWithValue(MultusNetworksAnnotation, "my-namespace/my-network"))
+		})
+
 	})
 })
 

--- a/internal/controller/virtualmachinebmc/controller_test.go
+++ b/internal/controller/virtualmachinebmc/controller_test.go
@@ -713,12 +713,13 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(svcPortNames).To(ContainElement(ipmiPortName))
 		})
 
-		It("Should create Pod with multus network annotation when networkRef is set", func() {
+		It("Should set Multus network annotation on Pod when NetworkRef is specified", func() {
 			ctx := context.Background()
-			vmName := "testvm-network-ref"
-			secretName := "secret-network-ref"
-			bmcName := "bmc-network-ref"
-			networkRef := "my-namespace/my-network"
+
+			vmName := "testvm-networkref"
+			secretName := "secret-networkref"
+			bmcName := "bmc-networkref"
+			networkRefValue := "mynetwork"
 
 			By("Creating the VirtualMachine and Secret")
 			vm := &kubevirtv1.VirtualMachine{
@@ -750,39 +751,58 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
-			By("Creating a VirtualMachineBMC with networkRef set")
+			By("Creating a VirtualMachineBMC with NetworkRef set")
 			virtualMachineBMC := &bmcv1.VirtualMachineBMC{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bmcName,
 					Namespace: testVirtualMachineBMCNamespace,
 				},
 				Spec: bmcv1.VirtualMachineBMCSpec{
-					VirtualMachineRef: &corev1.LocalObjectReference{Name: vmName},
-					AuthSecretRef:     &corev1.LocalObjectReference{Name: secretName},
-					NetworkRef:        networkRef,
+					VirtualMachineRef: &corev1.LocalObjectReference{
+						Name: vmName,
+					},
+					AuthSecretRef: &corev1.LocalObjectReference{
+						Name: secretName,
+					},
+					NetworkRef: networkRefValue,
 				},
 			}
 			Expect(k8sClient.Create(ctx, virtualMachineBMC)).To(Succeed())
 
-			By("Checking that the Pod is created with the multus network annotation")
+			By("Verifying the Pod has the Multus network annotation")
 			podLookupKey := types.NamespacedName{
 				Name:      vmName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
-			createdPod := &corev1.Pod{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, createdPod)
-				return err == nil
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, podLookupKey, pod); err != nil {
+					return false
+				}
+				val, ok := pod.Annotations[MultusNetworksAnnotation]
+				return ok && val == networkRefValue
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(createdPod.Annotations).To(HaveKeyWithValue(MultusNetworksAnnotation, networkRef))
+			By("Verifying the Pod does not have the annotation for empty NetworkRef")
+			// Look at the pod created without NetworkRef (from the first test) and
+			// ensure it does not have the Multus annotation.
+			firstPodLookupKey := types.NamespacedName{
+				Name:      testVMName + "-virtbmc",
+				Namespace: testVirtualMachineBMCNamespace,
+			}
+			var firstPod corev1.Pod
+			Expect(k8sClient.Get(ctx, firstPodLookupKey, &firstPod)).Should(Succeed())
+			Expect(firstPod.Annotations).ToNot(HaveKey(MultusNetworksAnnotation))
 		})
 
-		It("Should delete and recreate Pod when networkRef is changed", func() {
+		It("Should delete and recreate Pod when NetworkRef is changed", func() {
 			ctx := context.Background()
-			vmName := "testvm-network-change"
-			secretName := "secret-network-change"
-			bmcName := "bmc-network-change"
+
+			vmName := "testvm-networkref-change"
+			secretName := "secret-networkref-change"
+			bmcName := "bmc-networkref-change"
+			initialNetworkRef := "network-a"
+			updatedNetworkRef := "network-b"
 
 			By("Creating the VirtualMachine and Secret")
 			vm := &kubevirtv1.VirtualMachine{
@@ -808,55 +828,248 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				},
 				Type: corev1.SecretTypeOpaque,
 				Data: map[string][]byte{
-					"username": []byte("newadmin"),
-					"password": []byte("newpassword456"),
+					"username": []byte("admin"),
+					"password": []byte("password123"),
 				},
 			}
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
-			By("Creating a VirtualMachineBMC without networkRef")
+			By("Creating a VirtualMachineBMC with initial NetworkRef")
 			virtualMachineBMC := &bmcv1.VirtualMachineBMC{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bmcName,
 					Namespace: testVirtualMachineBMCNamespace,
 				},
 				Spec: bmcv1.VirtualMachineBMCSpec{
-					VirtualMachineRef: &corev1.LocalObjectReference{Name: vmName},
-					AuthSecretRef:     &corev1.LocalObjectReference{Name: secretName},
+					VirtualMachineRef: &corev1.LocalObjectReference{
+						Name: vmName,
+					},
+					AuthSecretRef: &corev1.LocalObjectReference{
+						Name: secretName,
+					},
+					NetworkRef: initialNetworkRef,
 				},
 			}
 			Expect(k8sClient.Create(ctx, virtualMachineBMC)).To(Succeed())
 
-			By("Waiting for the Pod to be created")
+			By("Waiting for initial Pod with original NetworkRef")
 			podLookupKey := types.NamespacedName{
 				Name:      vmName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
 			var originalPod corev1.Pod
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, &originalPod)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
-			Expect(originalPod.Annotations).ToNot(HaveKey(MultusNetworksAnnotation))
-			originalPodUID := originalPod.UID
-
-			By("Setting networkRef on the VirtualMachineBMC")
-			bmcLookupKey := types.NamespacedName{Name: bmcName, Namespace: testVirtualMachineBMCNamespace}
-			updatedBMC := &bmcv1.VirtualMachineBMC{}
-			Expect(k8sClient.Get(ctx, bmcLookupKey, updatedBMC)).Should(Succeed())
-			updatedBMC.Spec.NetworkRef = "my-namespace/my-network"
-			Expect(k8sClient.Update(ctx, updatedBMC)).Should(Succeed())
-
-			By("Verifying that a new Pod is created carrying the network annotation")
-			var newPod corev1.Pod
-			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, podLookupKey, &newPod); err != nil {
+				if err := k8sClient.Get(ctx, podLookupKey, &originalPod); err != nil {
 					return false
 				}
-				return newPod.UID != originalPodUID
+				val, ok := originalPod.Annotations[MultusNetworksAnnotation]
+				return ok && val == initialNetworkRef
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(newPod.Annotations).To(HaveKeyWithValue(MultusNetworksAnnotation, "my-namespace/my-network"))
+			originalPodUID := originalPod.UID
+
+			By("Updating the VirtualMachineBMC with a new NetworkRef")
+			updatedBMC := &bmcv1.VirtualMachineBMC{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bmcName, Namespace: testVirtualMachineBMCNamespace}, updatedBMC)).Should(Succeed())
+			updatedBMC.Spec.NetworkRef = updatedNetworkRef
+			Expect(k8sClient.Update(ctx, updatedBMC)).Should(Succeed())
+
+			By("Verifying the old Pod is deleted or replaced with a new UID")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, podLookupKey, pod); err != nil {
+					return false
+				}
+				return pod.UID != originalPodUID
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying the new Pod has the updated NetworkRef annotation")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, podLookupKey, pod); err != nil {
+					return false
+				}
+				val, ok := pod.Annotations[MultusNetworksAnnotation]
+				return ok && val == updatedNetworkRef
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying the new Pod retains correct labels and service account")
+			var newPod corev1.Pod
+			Expect(k8sClient.Get(ctx, podLookupKey, &newPod)).Should(Succeed())
+			Expect(newPod.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, bmcName))
+			Expect(newPod.Labels).To(HaveKeyWithValue(VMNameLabel, vmName))
+			Expect(newPod.Spec.ServiceAccountName).To(Equal(vmName + "-virtbmc"))
+		})
+
+		It("Should delete and recreate Pod when NetworkRef is removed", func() {
+			ctx := context.Background()
+
+			vmName := "testvm-networkref-remove"
+			secretName := "secret-networkref-remove"
+			bmcName := "bmc-networkref-remove"
+
+			By("Creating the VirtualMachine and Secret")
+			vm := &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Running: boolPtr(false),
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vm)).Should(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"username": []byte("admin"),
+					"password": []byte("password123"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating a VirtualMachineBMC with NetworkRef set")
+			virtualMachineBMC := &bmcv1.VirtualMachineBMC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bmcName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Spec: bmcv1.VirtualMachineBMCSpec{
+					VirtualMachineRef: &corev1.LocalObjectReference{
+						Name: vmName,
+					},
+					AuthSecretRef: &corev1.LocalObjectReference{
+						Name: secretName,
+					},
+					NetworkRef: "network-to-remove",
+				},
+			}
+			Expect(k8sClient.Create(ctx, virtualMachineBMC)).To(Succeed())
+
+			By("Waiting for Pod with NetworkRef annotation to be created")
+			podLookupKey := types.NamespacedName{
+				Name:      vmName + "-virtbmc",
+				Namespace: testVirtualMachineBMCNamespace,
+			}
+			var originalPod corev1.Pod
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, podLookupKey, &originalPod); err != nil {
+					return false
+				}
+				_, ok := originalPod.Annotations[MultusNetworksAnnotation]
+				return ok
+			}, timeout, interval).Should(BeTrue())
+
+			originalPodUID := originalPod.UID
+
+			By("Removing the NetworkRef from the VirtualMachineBMC")
+			updatedBMC := &bmcv1.VirtualMachineBMC{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bmcName, Namespace: testVirtualMachineBMCNamespace}, updatedBMC)).Should(Succeed())
+			updatedBMC.Spec.NetworkRef = ""
+			Expect(k8sClient.Update(ctx, updatedBMC)).Should(Succeed())
+
+			By("Verifying the old Pod is replaced with a new UID")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, podLookupKey, pod); err != nil {
+					return false
+				}
+				return pod.UID != originalPodUID
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying the new Pod does not have the Multus network annotation")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, podLookupKey, pod); err != nil {
+					return false
+				}
+				_, ok := pod.Annotations[MultusNetworksAnnotation]
+				return !ok
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should set JSON-format Multus network annotation on Pod when NetworkRef is JSON", func() {
+			ctx := context.Background()
+
+			vmName := "testvm-networkref-json"
+			secretName := "secret-networkref-json"
+			bmcName := "bmc-networkref-json"
+			jsonNetworkRef := fmt.Sprintf(
+				`[{"name": "mynet", "namespace": "%s", "interface": "net1"}]`,
+				testVirtualMachineBMCNamespace,
+			)
+
+			By("Creating the VirtualMachine and Secret")
+			vm := &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Running: boolPtr(false),
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vm)).Should(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"username": []byte("admin"),
+					"password": []byte("password123"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating a VirtualMachineBMC with JSON-format NetworkRef")
+			virtualMachineBMC := &bmcv1.VirtualMachineBMC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bmcName,
+					Namespace: testVirtualMachineBMCNamespace,
+				},
+				Spec: bmcv1.VirtualMachineBMCSpec{
+					VirtualMachineRef: &corev1.LocalObjectReference{
+						Name: vmName,
+					},
+					AuthSecretRef: &corev1.LocalObjectReference{
+						Name: secretName,
+					},
+					NetworkRef: jsonNetworkRef,
+				},
+			}
+			Expect(k8sClient.Create(ctx, virtualMachineBMC)).To(Succeed())
+
+			By("Verifying the Pod has the JSON-format Multus annotation")
+			podLookupKey := types.NamespacedName{
+				Name:      vmName + "-virtbmc",
+				Namespace: testVirtualMachineBMCNamespace,
+			}
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, podLookupKey, pod); err != nil {
+					return false
+				}
+				val, ok := pod.Annotations[MultusNetworksAnnotation]
+				return ok && val == jsonNetworkRef
+			}, timeout, interval).Should(BeTrue())
 		})
 
 	})

--- a/test/util/e2e_resources.go
+++ b/test/util/e2e_resources.go
@@ -28,6 +28,14 @@ const (
 	E2EWebhookServiceName      = "kubevirtbmc-webhook-service"
 	E2EWebhookServiceNamespace = "kubevirtbmc-system"
 	WebhookRegistrationDelay   = 10 * time.Second
+
+	// E2EMultusNetworkName is the name of the NetworkAttachmentDefinition
+	// created during e2e setup. It is used as the NetworkRef value in tests.
+	E2EMultusNetworkName = "test-multus-network"
+
+	// MultusNetworksAnnotation is the pod annotation key that Multus uses
+	// to attach additional network interfaces.
+	MultusNetworksAnnotation = "k8s.v1.cni.cncf.io/networks"
 )
 
 func AgentPodKey(namespace string) types.NamespacedName {

--- a/test/util/helper.go
+++ b/test/util/helper.go
@@ -15,6 +15,49 @@ const (
 	kubeVirtStableVersion  = "https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt"
 	kubeVirtOperatorURLFmt = "https://github.com/kubevirt/kubevirt/releases/download/%s/kubevirt-operator.yaml"
 	kubeVirtCRURLFmt       = "https://github.com/kubevirt/kubevirt/releases/download/%s/kubevirt-cr.yaml"
+
+	// NADCRDYAML is the NetworkAttachmentDefinition CRD definition.
+	// We apply only the CRD (not the full Multus daemonset) so the
+	// k8s.v1.cni.cncf.io/networks pod annotation is pure metadata —
+	// no actual CNI plugin runs, the pod starts normally with kindnet.
+	NADCRDYAML = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  scope: Namespaced
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+      - nad
+      - net-attach-def
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing Working Group to express the intent for attaching pods to one or more logical or physical networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
+              type: object
+              properties:
+                config:
+                  description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
+                  type: string`
 )
 
 var (
@@ -98,6 +141,64 @@ func HasDeclarativeHotplugVolumesEnabled() bool {
 
 func VirtualMediaPrerequisitesMet() bool {
 	return IsCDIInstalled() && HasDeclarativeHotplugVolumesEnabled()
+}
+
+// IsNADCRDInstalled checks whether the NetworkAttachmentDefinition CRD is
+// already registered in the cluster.
+func IsNADCRDInstalled() bool {
+	cmd := exec.Command("kubectl", "get", "crd",
+		"network-attachment-definitions.k8s.cni.cncf.io",
+		"--no-headers", "-o", "name", "--ignore-not-found")
+	output, err := Run(cmd)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(output) == "customresourcedefinition.apiextensions.k8s.io/network-attachment-definitions.k8s.cni.cncf.io"
+}
+
+// ApplyNADCRD registers the NetworkAttachmentDefinition CRD in the cluster.
+// No Multus daemonset is installed — the k8s.v1.cni.cncf.io/networks annotation
+// on pods is pure metadata. Pods start normally with the default CNI (kindnet).
+func ApplyNADCRD() error {
+	if IsNADCRDInstalled() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: NAD CRD is already installed. Skipping...\n")
+		return nil
+	}
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(NADCRDYAML)
+	dir, _ := getProjectDir()
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("apply NAD CRD: %w\noutput: %s", err, string(out))
+	}
+	_, _ = fmt.Fprintf(GinkgoWriter, "Applied NAD CRD: %s\n", string(out))
+	return nil
+}
+
+// CreateTestNetworkAttachmentDefinition creates a minimal bridge-based
+// NetworkAttachmentDefinition that e2e tests can reference via NetworkRef.
+func CreateTestNetworkAttachmentDefinition(namespace string) error {
+	nadYAML := fmt.Sprintf(`apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: test-multus-network
+  namespace: %s
+spec:
+  config: '{"cniVersion":"0.3.1","name":"test-multus-network","type":"bridge","bridge":"br-test"}'
+`, namespace)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(nadYAML)
+	dir, _ := getProjectDir()
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("create NetworkAttachmentDefinition: %w\noutput: %s", err, string(out))
+	}
+	_, _ = fmt.Fprintf(GinkgoWriter, "Created NetworkAttachmentDefinition: %s\n", string(out))
+	return nil
 }
 
 func IsKubeVirtInstalled() bool {

--- a/test/virtbmc-controller/controller_test.go
+++ b/test/virtbmc-controller/controller_test.go
@@ -332,5 +332,76 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 					len(svc.Spec.Ports) == 2
 			}, timeout, interval).Should(BeTrue(), "Service should be patched with IPMI port, preserving ClusterIP")
 		})
+
+		Context("when NetworkRef is set on a VirtualMachineBMC", func() {
+			It("should recreate Pod with Multus network annotation", func() {
+				By("recording the current Pod before NetworkRef change")
+				var podBefore corev1.Pod
+				Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &podBefore)).To(Succeed())
+				originalUID := podBefore.UID
+
+				By("verifying the current Pod does not have the Multus annotation")
+				_, hasAnnotation := podBefore.Annotations[util.MultusNetworksAnnotation]
+				Expect(hasAnnotation).To(BeFalse())
+
+				By("patching the VirtualMachineBMC to add NetworkRef")
+				bmc := &bmcv1.VirtualMachineBMC{}
+				Expect(k8sClient.Get(ctx, util.BMCKey(util.E2ENamespace), bmc)).To(Succeed())
+				bmc.Spec.NetworkRef = util.E2EMultusNetworkName
+				Expect(k8sClient.Update(ctx, bmc)).To(Succeed())
+
+				By("verifying the Pod is recreated with new UID and the Multus annotation")
+				Eventually(func() bool {
+					var pod corev1.Pod
+					if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &pod); err != nil {
+						return false
+					}
+					if pod.UID == originalUID {
+						return false
+					}
+					val, ok := pod.Annotations[util.MultusNetworksAnnotation]
+					return ok && val == util.E2EMultusNetworkName
+				}, timeout, interval).Should(BeTrue(), "Pod should be recreated with Multus network annotation")
+
+				// NOTE: we do NOT require the pod to reach Running state here.
+				// The delegate CNI (bridge) may fail in Kind depending on
+				// kernel modules / capabilities. The controller test focuses
+				// on annotation propagation and pod recreation, not CNI
+				// functionality.
+				By("verifying the Pod exists after controller reconciles")
+				Eventually(util.PodExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "Pod should exist after NetworkRef change")
+			})
+
+			It("should recreate Pod when NetworkRef value is changed", func() {
+				By("recording the current Pod")
+				var podBefore corev1.Pod
+				Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &podBefore)).To(Succeed())
+				originalUID := podBefore.UID
+
+				By("updating the VirtualMachineBMC to a different NetworkRef")
+				bmc := &bmcv1.VirtualMachineBMC{}
+				Expect(k8sClient.Get(ctx, util.BMCKey(util.E2ENamespace), bmc)).To(Succeed())
+				bmc.Spec.NetworkRef = "updated-multus-network"
+				Expect(k8sClient.Update(ctx, bmc)).To(Succeed())
+
+				By("verifying the Pod is recreated with updated Multus annotation")
+				Eventually(func() bool {
+					var pod corev1.Pod
+					if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &pod); err != nil {
+						return false
+					}
+					if pod.UID == originalUID {
+						return false
+					}
+					val, ok := pod.Annotations[util.MultusNetworksAnnotation]
+					return ok && val == "updated-multus-network"
+				}, timeout, interval).Should(BeTrue(), "Pod should be recreated with updated Multus annotation")
+
+				// NOTE: no Running check — delegate CNI may not succeed
+				// in all Kind environments (see comment in first NetworkRef test).
+				By("verifying the Pod exists after controller reconciles")
+				Eventually(util.PodExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "Pod should exist after NetworkRef change")
+			})
+		})
 	})
 })

--- a/test/virtbmc-controller/suite_test.go
+++ b/test/virtbmc-controller/suite_test.go
@@ -35,6 +35,7 @@ var (
 	skipKubeVirtInstall           = os.Getenv("KUBEVIRT_INSTALL_SKIP") == "true"
 	skipCertManagerInstall        = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	isCertManagerAlreadyInstalled = false
+	skipMultusInstall             = os.Getenv("MULTUS_INSTALL_SKIP") == "true"
 
 	repo = func() string {
 		if r := os.Getenv("REPO"); r != "" {
@@ -98,6 +99,16 @@ var _ = BeforeSuite(func() {
 		}
 	}
 
+	if !skipMultusInstall {
+		By("applying the NetworkAttachmentDefinition CRD")
+		err = util.ApplyNADCRD()
+		Expect(err).ToNot(HaveOccurred())
+
+		By("creating a test NetworkAttachmentDefinition")
+		err = util.CreateTestNetworkAttachmentDefinition(util.E2ENamespace)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
 	By("deploying the controller-manager")
 	cmd := exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", controllerManagerImage))
 	_, err = util.Run(cmd)
@@ -133,9 +144,16 @@ var _ = AfterSuite(func() {
 			return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Namespace: util.E2ENamespace, Name: util.E2EBMCName}, &bmc))
 		}, timeout, interval).Should(BeTrue(), "VirtualMachineBMC %s/%s should be deleted", util.E2ENamespace, util.E2EBMCName)
 	}
+
+	By("cleaning up the test NetworkAttachmentDefinition")
+	kcmd := exec.Command("kubectl", "delete", "network-attachment-definition",
+		util.E2EMultusNetworkName, "-n", util.E2ENamespace, "--ignore-not-found")
+	_, err := util.Run(kcmd)
+	Expect(err).ToNot(HaveOccurred(), "delete NetworkAttachmentDefinition %s/%s", util.E2ENamespace, util.E2EMultusNetworkName)
+
 	By("undeploying the controller-manager")
 	cmd := exec.Command("make", "undeploy")
-	_, err := util.Run(cmd)
+	_, err = util.Run(cmd)
 	Expect(err).ToNot(HaveOccurred(), "make undeploy should succeed")
 })
 

--- a/test/virtbmc-controller/suite_test.go
+++ b/test/virtbmc-controller/suite_test.go
@@ -29,13 +29,14 @@ import (
 const (
 	timeout  = time.Second * 60
 	interval = time.Millisecond * 250
+	strTrue  = "true"
 )
 
 var (
-	skipKubeVirtInstall           = os.Getenv("KUBEVIRT_INSTALL_SKIP") == "true"
-	skipCertManagerInstall        = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
+	skipKubeVirtInstall           = os.Getenv("KUBEVIRT_INSTALL_SKIP") == strTrue
+	skipCertManagerInstall        = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == strTrue
 	isCertManagerAlreadyInstalled = false
-	skipMultusInstall             = os.Getenv("MULTUS_INSTALL_SKIP") == "true"
+	skipMultusInstall             = os.Getenv("MULTUS_INSTALL_SKIP") == strTrue
 
 	repo = func() string {
 		if r := os.Getenv("REPO"); r != "" {


### PR DESCRIPTION
This implementation adds a single additional network via spec.networkRef, preserving the default Pod network. The controller recreates the virtBMC Pod when networkRef changes because Pod network attachments are immutable.

Fixes #150 