### PR TITLE
build: reduce built artifacts footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.5-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LINKFLAGS
@@ -10,7 +10,8 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Copy the go source
 COPY cmd/controller/main.go cmd/controller/main.go
@@ -23,7 +24,9 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "${LINKFLAGS}" -o manager cmd/controller/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -ldflags "${LINKFLAGS}" -o manager cmd/controller/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.virtbmc
+++ b/Dockerfile.virtbmc
@@ -1,5 +1,5 @@
 # Build the virtbmc binary
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.5-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LINKFLAGS
@@ -10,7 +10,8 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Copy the go source
 COPY cmd/virtbmc/main.go cmd/virtbmc/main.go
@@ -21,7 +22,9 @@ COPY pkg/ pkg/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "${LINKFLAGS}" -o virtbmc cmd/virtbmc/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -ldflags "${LINKFLAGS}" -o virtbmc cmd/virtbmc/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -146,12 +146,12 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 ##@ Build
 
-LINKFLAGS := "-X main.AppVersion=$(VERSION) -X main.GitCommit=$(COMMIT)"
+LINKFLAGS := "-s -w -X main.AppVersion=$(VERSION) -X main.GitCommit=$(COMMIT)"
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -ldflags $(LINKFLAGS) -o bin/manager cmd/controller/main.go
-	go build -ldflags $(LINKFLAGS) -o bin/virtbmc cmd/virtbmc/main.go
+	go build -trimpath -ldflags $(LINKFLAGS) -o bin/manager cmd/controller/main.go
+	go build -trimpath -ldflags $(LINKFLAGS) -o bin/virtbmc cmd/virtbmc/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.


### PR DESCRIPTION
```
$ docker image ls --format=table
REPOSITORY                              TAG                      IMAGE ID       CREATED              SIZE
starbops/virtbmc                        enh-201-head             41cdbbe2271b   54 seconds ago       78.5MB
starbops/virtbmc-controller             enh-201-head             6496ed346f0a   About a minute ago   75.1MB
starbops/virtbmc                        main-head                4bab3e3cd91a   7 hours ago          118MB
starbops/virtbmc-controller             main-head                77bf544bbcaa   7 hours ago          116MB
```

Related issue: #201