### PR TITLE
fix(ipmi): swap PowerCycle and HardReset method mappings

### DIFF
--- a/pkg/ipmi/handler.go
+++ b/pkg/ipmi/handler.go
@@ -38,13 +38,16 @@ func (h *handler) chassisControlHandler(m *goipmi.Message) goipmi.Response {
 		logrus.Info("power on")
 		err = h.rm.PowerOn()
 	case goipmi.ControlPowerCycle:
-		// Graceful power cycle (OS-level), per IPMI spec §28.3.
+		// Power cycle (turns system off then on), per IPMI spec §28.3.
+		// This is the most disruptive reset — it cuts power entirely,
+		// so we use the force variant.
 		logrus.Info("power cycle")
-		err = h.rm.PowerCycle()
+		err = h.rm.ForcePowerCycle()
 	case goipmi.ControlPowerHardReset:
 		// Hard reset (asserts system reset without power cycling), per IPMI spec §28.3.
-		logrus.Info("force power cycle")
-		err = h.rm.ForcePowerCycle()
+		// This is less disruptive than a full power cycle.
+		logrus.Info("hard reset")
+		err = h.rm.PowerCycle()
 	}
 
 	if err != nil {

--- a/pkg/ipmi/handler_test.go
+++ b/pkg/ipmi/handler_test.go
@@ -73,34 +73,34 @@ func TestChassisControlHandler(t *testing.T) {
 			expectedCode: goipmi.ErrInvalidState,
 		},
 		{
-			name:           "PowerCycle success",
+			name:           "PowerCycle (force) success",
 			chassisControl: goipmi.ControlPowerCycle,
-			expectedCall: func() {
-				mockRM.EXPECT().PowerCycle().Return(nil)
-			},
-			expectedCode: goipmi.CommandCompleted,
-		},
-		{
-			name:           "PowerCycle failure",
-			chassisControl: goipmi.ControlPowerCycle,
-			expectedCall: func() {
-				mockRM.EXPECT().PowerCycle().Return(fmt.Errorf("error"))
-			},
-			expectedCode: goipmi.ErrInvalidState,
-		},
-		{
-			name:           "ForcePowerCycle success",
-			chassisControl: goipmi.ControlPowerHardReset,
 			expectedCall: func() {
 				mockRM.EXPECT().ForcePowerCycle().Return(nil)
 			},
 			expectedCode: goipmi.CommandCompleted,
 		},
 		{
-			name:           "ForcePowerCycle failure",
-			chassisControl: goipmi.ControlPowerHardReset,
+			name:           "PowerCycle (force) failure",
+			chassisControl: goipmi.ControlPowerCycle,
 			expectedCall: func() {
 				mockRM.EXPECT().ForcePowerCycle().Return(fmt.Errorf("error"))
+			},
+			expectedCode: goipmi.ErrInvalidState,
+		},
+		{
+			name:           "HardReset success",
+			chassisControl: goipmi.ControlPowerHardReset,
+			expectedCall: func() {
+				mockRM.EXPECT().PowerCycle().Return(nil)
+			},
+			expectedCode: goipmi.CommandCompleted,
+		},
+		{
+			name:           "HardReset failure",
+			chassisControl: goipmi.ControlPowerHardReset,
+			expectedCall: func() {
+				mockRM.EXPECT().PowerCycle().Return(fmt.Errorf("error"))
 			},
 			expectedCode: goipmi.ErrInvalidState,
 		},


### PR DESCRIPTION
Per IPMI spec §28.3, Power Cycle (0x02) turns the system off then back on — cutting power entirely — which is the most disruptive reset. Hard Reset (0x03) asserts the system reset line without power cycling, making it strictly less brutal.

The previous mapping had these backwards:
  ControlPowerCycle    → PowerCycle()      (graceful restart)
  ControlPowerHardReset → ForcePowerCycle() (force restart)

Swap them so the more brutal operation maps to the force variant:
  ControlPowerCycle    → ForcePowerCycle() (GracePeriodSeconds=0)
  ControlPowerHardReset → PowerCycle()      (graceful restart)

fix https://github.com/kubevirtbmc/docs/pull/14#pullrequestreview-4608132557