### PR TITLE
ci: trigger publish workflow for version branches

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
     - main
+    - "v*"
 
 jobs:
   lint-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - "v*"
 
 jobs:
   build-main:


### PR DESCRIPTION
The proposed change will run the same CI flow for the `main` branch on other release branches, such as `v0.8`.