### PR TITLE
feat(controller): add configurable resource requests for agent pod

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -26,6 +26,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -70,6 +71,8 @@ func main() {
 		tlsOpts              []func(*tls.Config)
 		agentImageName       string
 		agentImageTag        string
+		agentCPURequest      string
+		agentMemoryRequest   string
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -78,6 +81,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager.")
 	flag.StringVar(&agentImageName, "agent-image-name", ctlvirtualmachinebmc.VirtBMCImageName, "The name of the agent image.")
 	flag.StringVar(&agentImageTag, "agent-image-tag", AppVersion, "The tag of the agent image.")
+	flag.StringVar(&agentCPURequest, "agent-cpu-request", ctlvirtualmachinebmc.DefaultAgentCPURequest, "The CPU request of the agent pod.")
+	flag.StringVar(&agentMemoryRequest, "agent-memory-request", ctlvirtualmachinebmc.DefaultAgentMemoryRequest, "The memory request of the agent pod.")
 	showVersion := flag.Bool("version", false, "Show version.")
 
 	opts := zap.Options{
@@ -93,6 +98,16 @@ func main() {
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Validate agent pod resource requests early, fail fast on misconfiguration
+	if _, err := resource.ParseQuantity(agentCPURequest); err != nil {
+		setupLog.Error(err, "invalid --agent-cpu-request", "value", agentCPURequest)
+		os.Exit(1)
+	}
+	if _, err := resource.ParseQuantity(agentMemoryRequest); err != nil {
+		setupLog.Error(err, "invalid --agent-memory-request", "value", agentMemoryRequest)
+		os.Exit(1)
+	}
 
 	// Disable HTTP/2 unless explicitly enabled
 	disableHTTP2 := func(c *tls.Config) {
@@ -145,10 +160,12 @@ func main() {
 	}
 
 	if err = (&ctlvirtualmachinebmc.VirtualMachineBMCReconciler{
-		Client:         mgr.GetClient(),
-		Scheme:         mgr.GetScheme(),
-		AgentImageName: agentImageName,
-		AgentImageTag:  agentImageTag,
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		AgentImageName:     agentImageName,
+		AgentImageTag:      agentImageTag,
+		AgentCPURequest:    agentCPURequest,
+		AgentMemoryRequest: agentMemoryRequest,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachineBMC")
 		os.Exit(1)

--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -3,6 +3,8 @@ package virtualmachinebmc
 const (
 	DefaultUsername            = "admin"
 	DefaultPassword            = "password"
+	DefaultAgentCPURequest     = "10m"
+	DefaultAgentMemoryRequest  = "128Mi"
 	virtBMCContainerName       = "virtbmc"
 	VirtBMCImageName           = "kubevirtbmc/virtbmc"
 	ipmiPort                   = 10623

--- a/internal/controller/virtualmachinebmc/controller.go
+++ b/internal/controller/virtualmachinebmc/controller.go
@@ -25,6 +25,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,8 +45,10 @@ type VirtualMachineBMCReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	AgentImageName string
-	AgentImageTag  string
+	AgentImageName     string
+	AgentImageTag      string
+	AgentCPURequest    string
+	AgentMemoryRequest string
 }
 
 const (
@@ -130,6 +133,23 @@ func (r *VirtualMachineBMCReconciler) ensureRBACResources(ctx context.Context, v
 	}
 
 	return nil
+}
+
+// agentResourceRequests returns the resource requests for the virtBMC agent
+// container, falling back to the defaults when not configured. Values are
+// validated at controller startup, so MustParse is safe here.
+func (r *VirtualMachineBMCReconciler) agentResourceRequests() corev1.ResourceList {
+	cpuRequest, memoryRequest := r.AgentCPURequest, r.AgentMemoryRequest
+	if cpuRequest == "" {
+		cpuRequest = DefaultAgentCPURequest
+	}
+	if memoryRequest == "" {
+		memoryRequest = DefaultAgentMemoryRequest
+	}
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(cpuRequest),
+		corev1.ResourceMemory: resource.MustParse(memoryRequest),
+	}
 }
 
 func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualMachineBMC *bmcv1.VirtualMachineBMC) *corev1.Pod {
@@ -221,6 +241,9 @@ func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualM
 						},
 						InitialDelaySeconds: 2,
 						PeriodSeconds:       10,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: r.agentResourceRequests(),
 					},
 				},
 			},

--- a/internal/controller/virtualmachinebmc/controller_test.go
+++ b/internal/controller/virtualmachinebmc/controller_test.go
@@ -149,6 +149,8 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(createdPod.Spec.ServiceAccountName).To(Equal(serviceAccountName))
 			Expect(createdPod.Spec.Containers).To(HaveLen(1))
 			Expect(createdPod.Spec.Containers[0].Name).To(Equal(virtBMCContainerName))
+			Expect(createdPod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal(DefaultAgentCPURequest))
+			Expect(createdPod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(DefaultAgentMemoryRequest))
 
 			By("Checking that the Service is created with correct name")
 			svcLookupKey := types.NamespacedName{


### PR DESCRIPTION
Some Kubernetes distributions refuse to schedule Pods without resource requests, and such Pods are excluded from reservation calculation and evicted first under node pressure.

Set default resource requests (cpu: 10m, memory: 128Mi) on the virtBMC agent container, overridable via new controller flags --agent-cpu-request and --agent-memory-request, following the same pattern as --agent-image-name/--agent-image-tag. Values are validated at controller startup.

The default value takes from our environment the real usage.
```
vm-z0bhof2g2zkpibx4yh6f-virtbmc               1/1     Running                  0          5h30m
vm-zgg670jcq8kot1z9qzdi-virtbmc               1/1     Running                  0          5h30m
vm-zujnib1ohefbs6b9qiig-virtbmc               1/1     Running                  0          5h31m
[root@node-3 ~]# kubectl top po vm-zujnib1ohefbs6b9qiig-virtbmc
NAME                              CPU(cores)   MEMORY(bytes)
vm-zujnib1ohefbs6b9qiig-virtbmc   2m           93Mi
[root@node-3 ~]# kubectl top po vm-zgg670jcq8kot1z9qzdi-virtbmc
NAME                              CPU(cores)   MEMORY(bytes)
vm-zgg670jcq8kot1z9qzdi-virtbmc   0m           87Mi
[root@node-3 ~]# kubectl top po vm-z0bhof2g2zkpibx4yh6f-virtbmc
NAME                              CPU(cores)   MEMORY(bytes)
vm-z0bhof2g2zkpibx4yh6f-virtbmc   1m           90Mi
```

Closes #246