### PR TITLE
security: set restricted-compliant securityContext on virtbmc Pod

### DIFF
--- a/internal/controller/virtualmachinebmc/controller.go
+++ b/internal/controller/virtualmachinebmc/controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -174,6 +175,12 @@ func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualM
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: serviceAccountName,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: ptr.To(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 			Containers: []corev1.Container{
 				{
 					Name:  virtBMCContainerName,
@@ -244,6 +251,14 @@ func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualM
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: r.agentResourceRequests(),
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						ReadOnlyRootFilesystem:   ptr.To(true),
+						RunAsNonRoot:             ptr.To(true),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
 					},
 				},
 			},

--- a/internal/controller/virtualmachinebmc/controller_test.go
+++ b/internal/controller/virtualmachinebmc/controller_test.go
@@ -152,6 +152,24 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(createdPod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal(DefaultAgentCPURequest))
 			Expect(createdPod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(DefaultAgentMemoryRequest))
 
+			By("Checking that the Pod and container have a restricted-compliant securityContext")
+			Expect(createdPod.Spec.SecurityContext).NotTo(BeNil())
+			Expect(createdPod.Spec.SecurityContext.RunAsNonRoot).NotTo(BeNil())
+			Expect(*createdPod.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(createdPod.Spec.SecurityContext.SeccompProfile).NotTo(BeNil())
+			Expect(createdPod.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+
+			container := createdPod.Spec.Containers[0]
+			Expect(container.SecurityContext).NotTo(BeNil())
+			Expect(container.SecurityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+			Expect(*container.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(container.SecurityContext.ReadOnlyRootFilesystem).NotTo(BeNil())
+			Expect(*container.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+			Expect(container.SecurityContext.RunAsNonRoot).NotTo(BeNil())
+			Expect(*container.SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(container.SecurityContext.Capabilities).NotTo(BeNil())
+			Expect(container.SecurityContext.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
+
 			By("Checking that the Service is created with correct name")
 			svcLookupKey := types.NamespacedName{
 				Name:      testVMName + "-virtbmc",


### PR DESCRIPTION
Same as title 

kubevirtbmc/security#2