### PR TITLE
fix(virtbmc): handle SIGTERM for graceful agent shutdown

### DIFF
--- a/cmd/virtbmc/main.go
+++ b/cmd/virtbmc/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -99,7 +100,7 @@ func run(ctx context.Context, options virtbmc.Options) error {
 	// trap Ctrl+C can call cancel on the context
 	ctx, cancel := context.WithCancel(ctx)
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	defer func() {
 		signal.Stop(c)
 		cancel()

--- a/test/virtbmc-agent/agent_helpers.go
+++ b/test/virtbmc-agent/agent_helpers.go
@@ -35,7 +35,7 @@ const (
 	issue191DiskName    = "oneshot-conflict-disk"
 	issue191RemovedDisk = "oneshot-removed-disk"
 	curlImage           = "curlimages/curl:latest"
-	ipmitoolImage       = "ghcr.io/halfcrazy/ipmitool:latest" // ipmitool v1.8.19
+	ipmitoolImage       = "kubevirtbmc/ipmitool:latest" // ipmitool v1.8.19
 	agentTestTimeout    = 60 * time.Second
 	agentTestInterval   = 250 * time.Millisecond
 	agentPodName        = "testvm-virtbmc"


### PR DESCRIPTION
Related issue: https://github.com/kubevirtbmc/kubevirtbmc/issues/257

The agent only registered SIGINT via signal.Notify, so when Kubernetes deleted the pod, SIGTERM fell through to the default disposition and killed the process (exit code 143), leaving the pod in Error state. Register SIGTERM as well so the context is cancelled and the agent shuts down gracefully with exit code 0.

Also switch the e2e ipmitool image to kubevirtbmc/ipmitool.