### PR TITLE
fix(controller): recreate agent pod on template drift

### DIFF
--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -17,4 +17,5 @@ const (
 	VMNameLabel                = "kubevirt.io/vm-name"
 	VirtualMachineBMCNamespace = "kubevirtbmc-system"
 	EnableIPMIAnnotation       = "bmc.kubevirt.io/enable-ipmi"
+	PodTemplateHashAnnotation  = "bmc.kubevirt.io/pod-template-hash"
 )

--- a/internal/controller/virtualmachinebmc/controller.go
+++ b/internal/controller/virtualmachinebmc/controller.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -454,18 +455,6 @@ func specIPMIEnabled(spec *bmcv1.VirtualMachineBMCSpec) bool {
 	return spec.IPMI != nil && spec.IPMI.Enabled != nil && *spec.IPMI.Enabled
 }
 
-func podIPMIEnabled(pod *corev1.Pod) bool {
-	val, ok := pod.Annotations[EnableIPMIAnnotation]
-	if !ok {
-		return false
-	}
-	enabled, err := strconv.ParseBool(val)
-	if err != nil {
-		return false
-	}
-	return enabled
-}
-
 func (r *VirtualMachineBMCReconciler) patchVirtBMCServicePorts(
 	ctx context.Context,
 	virtualMachineBMC *bmcv1.VirtualMachineBMC,
@@ -486,6 +475,10 @@ func (r *VirtualMachineBMCReconciler) patchVirtBMCServicePorts(
 
 	desired := r.constructServiceFromVirtualMachineBMC(virtualMachineBMC)
 
+	if apiequality.Semantic.DeepEqual(existing.Spec.Ports, desired.Spec.Ports) {
+		return nil
+	}
+
 	patch := client.MergeFrom(existing.DeepCopy())
 	existing.Spec.Ports = desired.Spec.Ports
 
@@ -499,11 +492,13 @@ func (r *VirtualMachineBMCReconciler) patchVirtBMCServicePorts(
 	return nil
 }
 
-// reconcileIPMIChange detects a mismatch between the spec's enableIPMI flag and
-// the stamped annotation on the existing pod. When a mismatch is found it
-// deletes the stale pod (ports are immutable) and patches the Service in-place
-// (preserving ClusterIP), then requeues so the main loop recreates the pod.
-func (r *VirtualMachineBMCReconciler) reconcileIPMIChange(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (requeue bool, err error) {
+// reconcilePodTemplateChange replaces an existing pod when its stamped template
+// hash differs from the current desired template.
+func (r *VirtualMachineBMCReconciler) reconcilePodTemplateChange(
+	ctx context.Context,
+	virtualMachineBMC *bmcv1.VirtualMachineBMC,
+	desiredPod *corev1.Pod,
+) (requeue bool, err error) {
 	log := log.FromContext(ctx)
 
 	pod, err := r.getVirtBMCPod(ctx, virtualMachineBMC)
@@ -515,22 +510,17 @@ func (r *VirtualMachineBMCReconciler) reconcileIPMIChange(ctx context.Context, v
 		return false, nil
 	}
 
-	currentHasIPMI := podIPMIEnabled(pod)
-	desiredHasIPMI := specIPMIEnabled(&virtualMachineBMC.Spec)
-
-	if currentHasIPMI == desiredHasIPMI {
+	currentHash := pod.Annotations[PodTemplateHashAnnotation]
+	desiredHash := desiredPod.Annotations[PodTemplateHashAnnotation]
+	if currentHash == desiredHash {
 		return false, nil
 	}
 
-	log.Info("enableIPMI changed, replacing pod and patching service",
-		"currentHasIPMI", currentHasIPMI,
-		"desiredHasIPMI", desiredHasIPMI)
+	log.Info("virtBMC Pod template changed, replacing pod",
+		"currentHash", currentHash,
+		"desiredHash", desiredHash)
 
 	if err := r.deleteVirtBMCPod(ctx, virtualMachineBMC); err != nil {
-		return false, err
-	}
-
-	if err := r.patchVirtBMCServicePorts(ctx, virtualMachineBMC); err != nil {
 		return false, err
 	}
 
@@ -593,7 +583,15 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	deleted, err := r.reconcileIPMIChange(ctx, &virtualMachineBMC)
+	pod := r.constructPodFromVirtualMachineBMC(&virtualMachineBMC)
+	if err := ctrl.SetControllerReference(&virtualMachineBMC, pod, r.Scheme); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := stampPodTemplateHash(pod); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to hash virtBMC Pod template: %w", err)
+	}
+
+	deleted, err := r.reconcilePodTemplateChange(ctx, &virtualMachineBMC, pod)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -602,12 +600,6 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if err := r.ensureRBACResources(ctx, &virtualMachineBMC); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Prepare the virtBMC Pod
-	pod := r.constructPodFromVirtualMachineBMC(&virtualMachineBMC)
-	if err := ctrl.SetControllerReference(&virtualMachineBMC, pod, r.Scheme); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -628,6 +620,14 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// Create the virtBMC Service on the cluster
 	if err := r.Create(ctx, svc); err != nil && !apierrors.IsAlreadyExists(err) {
 		log.Error(err, "unable to create Service for VirtualMachineBMC", "svc", svc)
+		return ctrl.Result{}, err
+	}
+
+	// Ensure the Service ports converge to the desired spec (e.g. after an
+	// IPMI toggle), preserving ClusterIP. This runs unconditionally because
+	// the pod-replacement path is not always reached — the agent pod may be
+	// absent at the moment of the toggle.
+	if err := r.patchVirtBMCServicePorts(ctx, &virtualMachineBMC); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/virtualmachinebmc/pod_template.go
+++ b/internal/controller/virtualmachinebmc/pod_template.go
@@ -1,0 +1,40 @@
+package virtualmachinebmc
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type podTemplate struct {
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Spec        corev1.PodSpec    `json:"spec"`
+}
+
+func stampPodTemplateHash(pod *corev1.Pod) error {
+	annotations := make(map[string]string, len(pod.Annotations))
+	for key, value := range pod.Annotations {
+		if key != PodTemplateHashAnnotation {
+			annotations[key] = value
+		}
+	}
+
+	data, err := json.Marshal(podTemplate{
+		Labels:      pod.Labels,
+		Annotations: annotations,
+		Spec:        pod.Spec,
+	})
+	if err != nil {
+		return err
+	}
+
+	sum := sha256.Sum256(data)
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations[PodTemplateHashAnnotation] = hex.EncodeToString(sum[:])
+	return nil
+}

--- a/internal/controller/virtualmachinebmc/pod_template_test.go
+++ b/internal/controller/virtualmachinebmc/pod_template_test.go
@@ -1,0 +1,79 @@
+package virtualmachinebmc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+)
+
+func TestStampPodTemplateHash(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"app": "virtbmc"},
+			Annotations: map[string]string{EnableIPMIAnnotation: "false"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: virtBMCContainerName, Image: "virtbmc:v1"}},
+		},
+	}
+
+	require.NoError(t, stampPodTemplateHash(pod))
+	firstHash := pod.Annotations[PodTemplateHashAnnotation]
+	require.NotEmpty(t, firstHash)
+
+	require.NoError(t, stampPodTemplateHash(pod))
+	require.Equal(t, firstHash, pod.Annotations[PodTemplateHashAnnotation])
+
+	pod.Spec.Containers[0].Image = "virtbmc:v2"
+	require.NoError(t, stampPodTemplateHash(pod))
+	require.NotEqual(t, firstHash, pod.Annotations[PodTemplateHashAnnotation])
+}
+
+func TestReconcilePodTemplateChangeDeletesStalePod(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	virtualMachineBMC := &bmcv1.VirtualMachineBMC{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-bmc", Namespace: "default"},
+		Spec: bmcv1.VirtualMachineBMCSpec{
+			VirtualMachineRef: &corev1.LocalObjectReference{Name: "test-vm"},
+			AuthSecretRef:     &corev1.LocalObjectReference{Name: "test-secret"},
+		},
+	}
+
+	reconciler := &VirtualMachineBMCReconciler{
+		Scheme:         scheme,
+		AgentImageName: "virtbmc",
+		AgentImageTag:  "v1",
+	}
+	existingPod := reconciler.constructPodFromVirtualMachineBMC(virtualMachineBMC)
+	require.NoError(t, stampPodTemplateHash(existingPod))
+
+	reconciler.Client = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existingPod).
+		Build()
+	reconciler.AgentImageTag = "v2"
+	desiredPod := reconciler.constructPodFromVirtualMachineBMC(virtualMachineBMC)
+	require.NoError(t, stampPodTemplateHash(desiredPod))
+
+	requeue, err := reconciler.reconcilePodTemplateChange(ctx, virtualMachineBMC, desiredPod)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	err = reconciler.Get(ctx, types.NamespacedName{
+		Name:      existingPod.Name,
+		Namespace: existingPod.Namespace,
+	}, &corev1.Pod{})
+	require.True(t, apierrors.IsNotFound(err))
+}


### PR DESCRIPTION
Recreate existing virtbmc pods when the agent image name or tag, CPU or memory requests, or probe configuration changes. Stamp the desired pod template hash, so upgrades replace stale agents while preserving Service identity.

As a tradeoff, existing instances without the podtemplatehash will also be recreated once after the version upgrade. Nevertheless, controller updates are most likely accompanied by agent version updates.

fix #262 