### PR TITLE
Add end-to-end (E2E) testing for the full server provisioning workflow based on Metal3/Ironic

### DIFF
--- a/.github/workflows/metal3-e2e.yml
+++ b/.github/workflows/metal3-e2e.yml
@@ -3,6 +3,8 @@ name: Metal3 Ironic Integration E2E
 # Release-grade; not triggered on PRs.
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 1"
   push:
     tags:
       - "v*"
@@ -66,9 +68,9 @@ jobs:
         with:
           # Consumed by cacheUserImageOnIronicHTTPD via os.TempDir(). Key covers
           # both ways the image can change: the METAL3_USER_IMAGE_* job env
-          # overrides and the default URL/checksum constants in provision_helpers.go.
+          # overrides and the default URL/checksum constants in provision_helpers_test.go.
           path: /tmp/metal3-user.qcow2
-          key: metal3-user-image-${{ hashFiles('test/metal3-e2e/provision_helpers.go') }}-${{ env.METAL3_USER_IMAGE_URL }}-${{ env.METAL3_USER_IMAGE_CHECKSUM }}
+          key: metal3-user-image-${{ hashFiles('test/metal3-e2e/provision_helpers_test.go') }}-${{ env.METAL3_USER_IMAGE_URL }}-${{ env.METAL3_USER_IMAGE_CHECKSUM }}
 
       - name: Metal3 e2e tests
         run: make metal3-e2e-test
@@ -78,21 +80,7 @@ jobs:
 
       - name: Collect diagnostics
         if: always()
-        run: |
-          mkdir -p artifacts
-          kubectl get pods -A > artifacts/pods.txt || true
-          kubectl get network-attachment-definitions -A -o yaml > artifacts/nads.yaml || true
-          kubectl get virtualmachinebmc,vm,vmi -A -o yaml > artifacts/kvbmc.yaml || true
-          kubectl get bmh -A -o yaml > artifacts/bmh.yaml || true
-          docker exec kvbmc-metal3-e2e-control-plane ip addr > artifacts/node-ip.txt || true
-          docker exec kvbmc-metal3-e2e-control-plane ip link show br-prov > artifacts/br-prov.txt || true
-          # Per-stage timestamps to locate provisioning stalls: dnsmasq shows
-          # DHCP rounds + TFTP events, httpd shows kernel/initramfs GETs,
-          # conductor shows deploy transitions and heartbeat waits.
-          IR=$(kubectl -n baremetal-operator-system get pod -l ironic.metal3.io/app=ironic-service -o jsonpath='{.items[0].metadata.name}')
-          for c in dnsmasq httpd ironic; do
-            kubectl -n baremetal-operator-system logs "$IR" -c "$c" --timestamps > "artifacts/ironic-$c.log" || true
-          done
+        run: make metal3-e2e-diagnostics
 
       - name: Upload diagnostics
         if: always()

--- a/.github/workflows/metal3-e2e.yml
+++ b/.github/workflows/metal3-e2e.yml
@@ -1,11 +1,11 @@
 name: Metal3 Ironic Integration E2E
 
-# Release-grade; PRs only run it when the Metal3 e2e harness itself changes.
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * 1"
   push:
+    branches:
+      - main
+      - "v*"
     tags:
       - "v*"
   pull_request:
@@ -24,7 +24,7 @@ jobs:
       REPO: kubevirtbmc
       MANAGER: virtbmc-controller
       AGENT: virtbmc
-      VERSION: ${{ github.event_name == 'pull_request' && format('pr-{0}-head', github.event.number) || github.ref_name }}
+      VERSION: ${{ github.event_name == 'pull_request' && format('pr-{0}-head', github.event.number) || (github.ref_type == 'branch' && format('{0}-head', github.ref_name) || github.ref_name) }}
       GIT_COMMIT: ${{ github.sha }}
       KIND_CLUSTER: kvbmc-metal3-e2e
       CERT_MANAGER_VERSION: v1.14.2

--- a/.github/workflows/metal3-e2e.yml
+++ b/.github/workflows/metal3-e2e.yml
@@ -1,0 +1,106 @@
+name: Metal3 Ironic Integration E2E
+
+# Release-grade; not triggered on PRs.
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  metal3-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    env:
+      REPO: kubevirtbmc
+      MANAGER: virtbmc-controller
+      AGENT: virtbmc
+      VERSION: ${{ github.ref_name }}
+      TAG: ${{ github.ref_name }}
+      GIT_COMMIT: ${{ github.sha }}
+      KIND_CLUSTER: kvbmc-metal3-e2e
+      CERT_MANAGER_VERSION: v1.14.2
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker build manager
+        uses: docker/build-push-action@v6
+        with:
+          provenance: false
+          context: .
+          build-args: |
+            LINKFLAGS=-X main.AppVersion=${{ env.VERSION }} -X main.GitCommit=${{ env.GIT_COMMIT }}
+          file: Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.REPO }}/${{ env.MANAGER }}:${{ env.TAG }}
+
+      - name: Docker build agent
+        uses: docker/build-push-action@v6
+        with:
+          provenance: false
+          context: .
+          build-args: |
+            LINKFLAGS=-X main.AppVersion=${{ env.VERSION }} -X main.GitCommit=${{ env.GIT_COMMIT }}
+          file: Dockerfile.virtbmc
+          push: false
+          load: true
+          tags: ${{ env.REPO }}/${{ env.AGENT }}:${{ env.TAG }}
+
+      - name: Metal3 e2e setup (Kind + br-prov + Multus)
+        run: make metal3-e2e-setup
+
+      - name: Cache Metal3 user image
+        uses: actions/cache@v4
+        with:
+          # Consumed by cacheUserImageOnIronicHTTPD via os.TempDir(). Key covers
+          # both ways the image can change: the METAL3_USER_IMAGE_* job env
+          # overrides and the default URL/checksum constants in provision_helpers.go.
+          path: /tmp/metal3-user.qcow2
+          key: metal3-user-image-${{ hashFiles('test/metal3-e2e/provision_helpers.go') }}-${{ env.METAL3_USER_IMAGE_URL }}-${{ env.METAL3_USER_IMAGE_CHECKSUM }}
+
+      - name: Metal3 e2e tests
+        run: make metal3-e2e-test
+        env:
+          REPO: ${{ env.REPO }}
+          TAG: ${{ env.TAG }}
+
+      - name: Collect diagnostics
+        if: always()
+        run: |
+          mkdir -p artifacts
+          kubectl get pods -A > artifacts/pods.txt || true
+          kubectl get network-attachment-definitions -A -o yaml > artifacts/nads.yaml || true
+          kubectl get virtualmachinebmc,vm,vmi -A -o yaml > artifacts/kvbmc.yaml || true
+          kubectl get bmh -A -o yaml > artifacts/bmh.yaml || true
+          docker exec kvbmc-metal3-e2e-control-plane ip addr > artifacts/node-ip.txt || true
+          docker exec kvbmc-metal3-e2e-control-plane ip link show br-prov > artifacts/br-prov.txt || true
+          # Per-stage timestamps to locate provisioning stalls: dnsmasq shows
+          # DHCP rounds + TFTP events, httpd shows kernel/initramfs GETs,
+          # conductor shows deploy transitions and heartbeat waits.
+          IR=$(kubectl -n baremetal-operator-system get pod -l ironic.metal3.io/app=ironic-service -o jsonpath='{.items[0].metadata.name}')
+          for c in dnsmasq httpd ironic; do
+            kubectl -n baremetal-operator-system logs "$IR" -c "$c" --timestamps > "artifacts/ironic-$c.log" || true
+          done
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: metal3-e2e-diagnostics
+          path: artifacts/
+
+      - name: Metal3 e2e teardown
+        if: always()
+        run: make metal3-e2e-teardown

--- a/.github/workflows/metal3-e2e.yml
+++ b/.github/workflows/metal3-e2e.yml
@@ -1,6 +1,6 @@
 name: Metal3 Ironic Integration E2E
 
-# Release-grade; not triggered on PRs.
+# Release-grade; PRs only run it when the Metal3 e2e harness itself changes.
 on:
   workflow_dispatch:
   schedule:
@@ -8,6 +8,11 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - "hack/metal3-e2e/**"
+      - "test/metal3-e2e/**"
+      - ".github/workflows/metal3-e2e.yml"
 
 jobs:
   metal3-e2e:
@@ -19,8 +24,7 @@ jobs:
       REPO: kubevirtbmc
       MANAGER: virtbmc-controller
       AGENT: virtbmc
-      VERSION: ${{ github.ref_name }}
-      TAG: ${{ github.ref_name }}
+      VERSION: ${{ github.event_name == 'pull_request' && format('pr-{0}-head', github.event.number) || github.ref_name }}
       GIT_COMMIT: ${{ github.sha }}
       KIND_CLUSTER: kvbmc-metal3-e2e
       CERT_MANAGER_VERSION: v1.14.2
@@ -46,7 +50,7 @@ jobs:
           file: Dockerfile
           push: false
           load: true
-          tags: ${{ env.REPO }}/${{ env.MANAGER }}:${{ env.TAG }}
+          tags: ${{ env.REPO }}/${{ env.MANAGER }}:${{ env.VERSION }}
 
       - name: Docker build agent
         uses: docker/build-push-action@v6
@@ -58,7 +62,7 @@ jobs:
           file: Dockerfile.virtbmc
           push: false
           load: true
-          tags: ${{ env.REPO }}/${{ env.AGENT }}:${{ env.TAG }}
+          tags: ${{ env.REPO }}/${{ env.AGENT }}:${{ env.VERSION }}
 
       - name: Metal3 e2e setup (Kind + br-prov + Multus)
         run: make metal3-e2e-setup
@@ -74,9 +78,6 @@ jobs:
 
       - name: Metal3 e2e tests
         run: make metal3-e2e-test
-        env:
-          REPO: ${{ env.REPO }}
-          TAG: ${{ env.TAG }}
 
       - name: Collect diagnostics
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,11 @@ endif
 # tools. (i.e. podman)
 CONTAINER_TOOL ?= docker
 
-# KUBEVIRT API version to use
+# KUBEVIRT API version to use (CRD codegen); keep in sync with KUBEVIRT_VERSION.
 KUBEVIRT_API_VERSION = v1.8.4
+# Runtime install pin for e2e (test/util InstallKubeVirt).
+export KUBEVIRT_VERSION ?= $(KUBEVIRT_API_VERSION)
+export CDI_VERSION ?= v1.65.0
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -146,12 +149,16 @@ e2e-setup: kind cloud-provider-kind ## Setup end-to-end test environment.
 
 .PHONY: e2e-teardown
 e2e-teardown: kind ## Teardown end-to-end test environment.
+ifeq ($(KEEP_ENV),true)
+	@echo "KEEP_ENV=true, skipping e2e-teardown"
+else
 	@if [ -f $(CLOUD_PROVIDER_KIND_PID_FILE) ]; then \
 		echo "Stopping cloud-provider-kind..."; \
 		kill $$(cat $(CLOUD_PROVIDER_KIND_PID_FILE)) 2>/dev/null || true; \
 		rm -f $(CLOUD_PROVIDER_KIND_PID_FILE); \
 	fi
 	$(KIND) delete cluster --name kvbmc-e2e
+endif
 
 .PHONY: e2e-test
 e2e-test: generate fmt vet kind ## Run end-to-end tests (controller first, then agent: IPMI, Redfish, Virtual Media).
@@ -160,6 +167,42 @@ e2e-test: generate fmt vet kind ## Run end-to-end tests (controller first, then 
 
 .PHONY: local-e2e-test
 local-e2e-test: e2e-setup e2e-test e2e-teardown ## Run end-to-end tests locally.
+
+##@ Metal3 / Ironic integration e2e (release-grade; not run on PRs)
+
+# External dependency versions — exported into hack/metal3-e2e/*.sh and go e2e.
+# Override per-run: make metal3-e2e-setup IRSO_VERSION=v0.11.0
+export IRSO_VERSION ?= v0.10.0
+export BMO_VERSION ?= v0.13.2
+export IRONIC_VERSION ?= 37.0
+export MULTUS_VERSION ?= v4.2.2
+export CNI_PLUGINS_VERSION ?= v1.6.2
+# CERT_MANAGER_VERSION / KUBEVIRT_VERSION / CDI_VERSION are exported above.
+
+METAL3_CLUSTER ?= kvbmc-metal3-e2e
+
+.PHONY: metal3-e2e-setup
+metal3-e2e-setup: kind ## Create single-node Kind + br-prov + Multus + IrSO/BMO.
+	@$(KIND) get clusters 2>/dev/null | grep -q $(METAL3_CLUSTER) || \
+		$(KIND) create cluster --name $(METAL3_CLUSTER) --config test/kind-config-metal3.yaml --image=kindest/node:$(KIND_K8S_VERSION)
+	@CLUSTER_NAME=$(METAL3_CLUSTER) bash hack/metal3-e2e/setup-prov-net.sh
+	@CLUSTER_NAME=$(METAL3_CLUSTER) bash hack/metal3-e2e/install-metal3.sh
+
+.PHONY: metal3-e2e-teardown
+metal3-e2e-teardown: kind ## Tear down Metal3 stack, Multus NAD/br-prov, and Kind cluster. KEEP_ENV=true skips.
+ifeq ($(KEEP_ENV),true)
+	@echo "KEEP_ENV=true, skipping metal3-e2e-teardown"
+else
+	$(KIND) delete cluster --name $(METAL3_CLUSTER)
+endif
+
+.PHONY: metal3-e2e-test
+metal3-e2e-test: generate fmt vet ## Run Metal3/Ironic integration tests (requires metal3-e2e-setup + built images).
+	# go test -timeout bounds the process; -ginkgo.timeout bounds the suite (Ginkgo default is 1h).
+	KIND_CLUSTER=$(METAL3_CLUSTER) go test -v ./test/metal3-e2e/... -ginkgo.v -ginkgo.timeout=120m -timeout 120m
+
+.PHONY: local-metal3-e2e-test
+local-metal3-e2e-test: metal3-e2e-setup metal3-e2e-test metal3-e2e-teardown ## Full Metal3 e2e locally (heavy). KEEP_ENV=true keeps Kind+stack.
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,10 @@ metal3-e2e-test: generate fmt vet ## Run Metal3/Ironic integration tests (requir
 	# go test -timeout bounds the process; -ginkgo.timeout bounds the suite (Ginkgo default is 1h).
 	KIND_CLUSTER=$(METAL3_CLUSTER) go test -v ./test/metal3-e2e/... -ginkgo.v -ginkgo.timeout=120m -timeout 120m
 
+.PHONY: metal3-e2e-diagnostics
+metal3-e2e-diagnostics: ## Dump Metal3 e2e diagnostics (pods, BMH, Ironic logs) into ./artifacts. Best-effort, never fails.
+	@CLUSTER_NAME=$(METAL3_CLUSTER) bash hack/metal3-e2e/collect-diagnostics.sh
+
 .PHONY: local-metal3-e2e-test
 local-metal3-e2e-test: metal3-e2e-setup metal3-e2e-test metal3-e2e-teardown ## Full Metal3 e2e locally (heavy). KEEP_ENV=true keeps Kind+stack.
 

--- a/hack/metal3-e2e/collect-diagnostics.sh
+++ b/hack/metal3-e2e/collect-diagnostics.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Best-effort diagnostics dump for Metal3 e2e runs into ${OUT_DIR}.
+# Runs after possibly-broken setups (CI `if: always()`), so it must never fail.
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+set +e # common.sh enables errexit; a missing resource must not abort the rest.
+
+OUT_DIR="${OUT_DIR:-artifacts}"
+IRONIC_NS="${IRONIC_NS:-baremetal-operator-system}"
+mkdir -p "${OUT_DIR}"
+
+kubectl get pods -A >"${OUT_DIR}/pods.txt" 2>&1
+kubectl get network-attachment-definitions -A -o yaml >"${OUT_DIR}/nads.yaml" 2>&1
+kubectl get virtualmachinebmc,vm,vmi -A -o yaml >"${OUT_DIR}/kvbmc.yaml" 2>&1
+kubectl get bmh -A -o yaml >"${OUT_DIR}/bmh.yaml" 2>&1
+docker exec "${KIND_NODE}" ip addr >"${OUT_DIR}/node-ip.txt" 2>&1
+docker exec "${KIND_NODE}" ip link show "${BR_NAME}" >"${OUT_DIR}/br-prov.txt" 2>&1
+
+# Per-stage timestamps to locate provisioning stalls: dnsmasq shows
+# DHCP rounds + TFTP events, httpd shows kernel/initramfs GETs,
+# conductor shows deploy transitions and heartbeat waits.
+IR=$(kubectl -n "${IRONIC_NS}" get pod -l ironic.metal3.io/app=ironic-service \
+  -o jsonpath='{.items[0].metadata.name}')
+if [[ -n "${IR}" ]]; then
+  for c in dnsmasq httpd ironic; do
+    kubectl -n "${IRONIC_NS}" logs "${IR}" -c "${c}" --timestamps >"${OUT_DIR}/ironic-${c}.log" 2>&1
+  done
+fi
+
+echo "==> diagnostics written to ${OUT_DIR}/"

--- a/hack/metal3-e2e/common.sh
+++ b/hack/metal3-e2e/common.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Shared helpers for Metal3 e2e provisioning-network setup.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLUSTER_NAME="${CLUSTER_NAME:-kvbmc-metal3-e2e}"
+KIND_NODE="${KIND_NODE:-${CLUSTER_NAME}-control-plane}"
+BR_NAME="${BR_NAME:-br-prov}"
+# Single source of truth for the node-local provisioning L2.
+BR_CIDR="${BR_CIDR:-172.22.0.1/24}"
+BR_IP="${BR_IP:-${BR_CIDR%%/*}}"
+BR_SUBNET="${BR_SUBNET:-${BR_IP%.*}.0/24}"
+DHCP_RANGE_BEGIN="${DHCP_RANGE_BEGIN:-${BR_IP%.*}.100}"
+DHCP_RANGE_END="${DHCP_RANGE_END:-${BR_IP%.*}.200}"
+# envsubst only sees exported variables (heredoc bash expansion did not need this).
+export CLUSTER_NAME KIND_NODE BR_NAME BR_CIDR BR_IP BR_SUBNET DHCP_RANGE_BEGIN DHCP_RANGE_END
+
+# Version pins live in the Makefile (exported). Fallbacks keep direct script use working.
+MULTUS_VERSION="${MULTUS_VERSION:-v4.2.2}"
+MULTUS_MANIFEST="${MULTUS_MANIFEST:-https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/${MULTUS_VERSION}/deployments/multus-daemonset-thick.yml}"
+NAD_NS="${NAD_NS:-default}"
+NAD_NAME="${NAD_NAME:-provisioning}"
+export MULTUS_VERSION MULTUS_MANIFEST NAD_NS NAD_NAME
+
+CNI_PLUGINS_VERSION="${CNI_PLUGINS_VERSION:-v1.6.2}"
+export CNI_PLUGINS_VERSION
+
+kind_node_exists() {
+  docker inspect "${KIND_NODE}" >/dev/null 2>&1
+}
+
+require_kind_node() {
+  if ! kind_node_exists; then
+    echo "error: kind node container ${KIND_NODE} not found; create the cluster first (make metal3-e2e-setup)" >&2
+    exit 1
+  fi
+}
+
+# Kind node images ship only a subset of CNI binaries; Multus bridge NAD needs "bridge".
+install_cni_plugins() {
+  local arch tmp need=()
+  arch="$(docker exec "${KIND_NODE}" uname -m)"
+  case "${arch}" in
+    x86_64) arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+  esac
+  for plugin in bridge; do
+    if ! docker exec "${KIND_NODE}" test -x "/opt/cni/bin/${plugin}"; then
+      need+=("${plugin}")
+    fi
+  done
+  if [[ ${#need[@]} -eq 0 ]]; then
+    echo "==> CNI plugins already present on ${KIND_NODE}"
+    return 0
+  fi
+  echo "==> installing CNI plugins (${need[*]}) ${CNI_PLUGINS_VERSION} on ${KIND_NODE}"
+  tmp="$(mktemp -d)"
+  curl -fsSL -o "${tmp}/cni-plugins.tgz" \
+    "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${arch}-${CNI_PLUGINS_VERSION}.tgz"
+  tar -xzf "${tmp}/cni-plugins.tgz" -C "${tmp}"
+  for plugin in "${need[@]}"; do
+    docker cp "${tmp}/${plugin}" "${KIND_NODE}:/opt/cni/bin/${plugin}"
+    docker exec "${KIND_NODE}" chmod +x "/opt/cni/bin/${plugin}"
+  done
+  rm -rf "${tmp}"
+}

--- a/hack/metal3-e2e/fixtures/bmo-auth-patch.yaml
+++ b/hack/metal3-e2e/fixtures/bmo-auth-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baremetal-operator-controller-manager
+  namespace: baremetal-operator-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          volumeMounts:
+            - name: ironic-credentials
+              mountPath: /opt/metal3/auth/ironic
+              readOnly: true
+      volumes:
+        - name: ironic-credentials
+          secret:
+            secretName: ironic-credentials

--- a/hack/metal3-e2e/fixtures/bmo-configmap.yaml
+++ b/hack/metal3-e2e/fixtures/bmo-configmap.yaml
@@ -1,0 +1,13 @@
+# Applied by install-metal3.sh via envsubst.
+# BMO reads Ironic connection settings from a ConfigMap literally named "ironic"
+# in its own namespace; values point at the IrSO Service DNS, not br-prov host ports.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ironic
+  namespace: ${IRONIC_NS}
+data:
+  IRONIC_ENDPOINT: "${IRONIC_ENDPOINT}"
+  DEPLOY_KERNEL_URL: "${DEPLOY_KERNEL_URL}"
+  DEPLOY_RAMDISK_URL: "${DEPLOY_RAMDISK_URL}"
+  CACHEURL: "${CACHEURL}"

--- a/hack/metal3-e2e/fixtures/ironic.yaml
+++ b/hack/metal3-e2e/fixtures/ironic.yaml
@@ -1,0 +1,16 @@
+# Applied by install-metal3.sh via envsubst (versions from Makefile exports).
+# BMO must use IrSO Service DNS (:80 API, :8080 images), not br-prov host ports.
+apiVersion: ironic.metal3.io/v1alpha1
+kind: Ironic
+metadata:
+  name: ironic
+  namespace: ${IRONIC_NS}
+spec:
+  version: "${IRONIC_VERSION}"
+  networking:
+    interface: ${BR_NAME}
+    ipAddress: "${BR_IP}" # PXE/DHCP on provisioning L2 only
+    dhcp:
+      networkCIDR: "${BR_SUBNET}"
+      rangeBegin: "${DHCP_RANGE_BEGIN}"
+      rangeEnd: "${DHCP_RANGE_END}"

--- a/hack/metal3-e2e/fixtures/nad-provisioning.yaml
+++ b/hack/metal3-e2e/fixtures/nad-provisioning.yaml
@@ -1,0 +1,15 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ${NAD_NAME}
+  namespace: ${NAD_NS}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "${NAD_NAME}",
+      "type": "bridge",
+      "bridge": "${BR_NAME}",
+      "promiscMode": true,
+      "ipam": {}
+    }

--- a/hack/metal3-e2e/install-metal3.sh
+++ b/hack/metal3-e2e/install-metal3.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Install IrSO + Ironic CR + BMO, wired for Kind (br-prov + cluster DNS).
+set -euo pipefail
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+# Version pins live in the Makefile (exported). Fallbacks keep direct script use working.
+IRSO_VERSION="${IRSO_VERSION:-v0.10.0}"
+BMO_VERSION="${BMO_VERSION:-v0.13.2}"
+IRONIC_VERSION="${IRONIC_VERSION:-37.0}"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.14.2}"
+IRONIC_NS="${IRONIC_NS:-baremetal-operator-system}"
+export IRSO_VERSION BMO_VERSION IRONIC_VERSION CERT_MANAGER_VERSION IRONIC_NS
+IRSO_MANIFEST="${IRSO_MANIFEST:-https://github.com/metal3-io/ironic-standalone-operator/releases/download/${IRSO_VERSION}/install.yaml}"
+BMO_MANIFEST="${BMO_MANIFEST:-https://github.com/metal3-io/baremetal-operator/releases/download/${BMO_VERSION}/baremetal-operator.yaml}"
+
+require_kind_node
+
+if ! kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
+  echo "==> installing cert-manager ${CERT_MANAGER_VERSION}"
+  kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+  kubectl -n cert-manager wait --for=condition=Available --timeout=300s deployment/cert-manager-webhook
+fi
+
+echo "==> installing Ironic Standalone Operator ${IRSO_VERSION}"
+kubectl apply -f "${IRSO_MANIFEST}"
+kubectl -n ironic-standalone-operator-system wait --for=condition=Available \
+  deployment/ironic-standalone-operator-controller-manager --timeout=180s
+
+echo "==> ensuring namespace ${IRONIC_NS}"
+kubectl create namespace "${IRONIC_NS}" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "==> applying Ironic CR version=${IRONIC_VERSION} (${BR_NAME} ${BR_IP}, DHCP ${DHCP_RANGE_BEGIN}-${DHCP_RANGE_END})"
+# Limit substitution to known placeholders so stray $ in comments cannot break YAML.
+envsubst '${IRONIC_NS} ${IRONIC_VERSION} ${BR_NAME} ${BR_IP} ${BR_SUBNET} ${DHCP_RANGE_BEGIN} ${DHCP_RANGE_END}' \
+  < "${ROOT_DIR}/hack/metal3-e2e/fixtures/ironic.yaml" | kubectl apply -f -
+kubectl -n "${IRONIC_NS}" wait --for=condition=Ready --timeout=600s ironic/ironic
+
+SECRET=$(kubectl get ironic/ironic -n "${IRONIC_NS}" -o jsonpath='{.spec.apiCredentialsName}')
+if [[ -z "${SECRET}" ]]; then
+  echo "error: Ironic CR has empty spec.apiCredentialsName" >&2
+  exit 1
+fi
+echo "==> Ironic API credentials secret: ${SECRET}"
+
+# IrSO ClusterIP Service maps API→80, images→8080 (hostNetwork target ports 6385/6180).
+# Prefer Service DNS over br-prov IP so BMO does not depend on a hardcoded address.
+IRONIC_ENDPOINT="http://ironic.${IRONIC_NS}.svc/v1/"
+DEPLOY_KERNEL_URL="http://ironic.${IRONIC_NS}.svc:8080/images/ironic-python-agent.kernel"
+DEPLOY_RAMDISK_URL="http://ironic.${IRONIC_NS}.svc:8080/images/ironic-python-agent.initramfs"
+CACHEURL="http://ironic.${IRONIC_NS}.svc:8080/images"
+
+echo "==> installing Bare Metal Operator ${BMO_VERSION}"
+kubectl apply -f "${BMO_MANIFEST}"
+
+echo "==> pointing BMO at IrSO Service (${IRONIC_ENDPOINT})"
+kubectl -n "${IRONIC_NS}" apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ironic
+  namespace: ${IRONIC_NS}
+data:
+  IRONIC_ENDPOINT: "${IRONIC_ENDPOINT}"
+  DEPLOY_KERNEL_URL: "${DEPLOY_KERNEL_URL}"
+  DEPLOY_RAMDISK_URL: "${DEPLOY_RAMDISK_URL}"
+  CACHEURL: "${CACHEURL}"
+EOF
+
+USER=$(kubectl get secret "${SECRET}" -n "${IRONIC_NS}" -o jsonpath='{.data.username}' | base64 -d)
+PASS=$(kubectl get secret "${SECRET}" -n "${IRONIC_NS}" -o jsonpath='{.data.password}' | base64 -d)
+kubectl -n "${IRONIC_NS}" apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ironic-credentials
+  namespace: ${IRONIC_NS}
+type: Opaque
+stringData:
+  username: "${USER}"
+  password: "${PASS}"
+EOF
+
+kubectl -n "${IRONIC_NS}" patch deployment baremetal-operator-controller-manager \
+  --patch-file="${ROOT_DIR}/hack/metal3-e2e/fixtures/bmo-auth-patch.yaml"
+kubectl -n "${IRONIC_NS}" rollout status deployment/baremetal-operator-controller-manager --timeout=300s
+
+echo "==> Metal3 stack ready (IrSO + Ironic + BMO)"
+kubectl -n "${IRONIC_NS}" get ironic,deploy,pods

--- a/hack/metal3-e2e/install-metal3.sh
+++ b/hack/metal3-e2e/install-metal3.sh
@@ -45,41 +45,25 @@ echo "==> Ironic API credentials secret: ${SECRET}"
 
 # IrSO ClusterIP Service maps API→80, images→8080 (hostNetwork target ports 6385/6180).
 # Prefer Service DNS over br-prov IP so BMO does not depend on a hardcoded address.
+# Exported so envsubst on fixtures/bmo-configmap.yaml can see them.
 IRONIC_ENDPOINT="http://ironic.${IRONIC_NS}.svc/v1/"
 DEPLOY_KERNEL_URL="http://ironic.${IRONIC_NS}.svc:8080/images/ironic-python-agent.kernel"
 DEPLOY_RAMDISK_URL="http://ironic.${IRONIC_NS}.svc:8080/images/ironic-python-agent.initramfs"
 CACHEURL="http://ironic.${IRONIC_NS}.svc:8080/images"
+export IRONIC_ENDPOINT DEPLOY_KERNEL_URL DEPLOY_RAMDISK_URL CACHEURL
 
 echo "==> installing Bare Metal Operator ${BMO_VERSION}"
 kubectl apply -f "${BMO_MANIFEST}"
 
 echo "==> pointing BMO at IrSO Service (${IRONIC_ENDPOINT})"
-kubectl -n "${IRONIC_NS}" apply -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ironic
-  namespace: ${IRONIC_NS}
-data:
-  IRONIC_ENDPOINT: "${IRONIC_ENDPOINT}"
-  DEPLOY_KERNEL_URL: "${DEPLOY_KERNEL_URL}"
-  DEPLOY_RAMDISK_URL: "${DEPLOY_RAMDISK_URL}"
-  CACHEURL: "${CACHEURL}"
-EOF
+envsubst '${IRONIC_NS} ${IRONIC_ENDPOINT} ${DEPLOY_KERNEL_URL} ${DEPLOY_RAMDISK_URL} ${CACHEURL}' \
+  < "${ROOT_DIR}/hack/metal3-e2e/fixtures/bmo-configmap.yaml" | kubectl apply -f -
 
 USER=$(kubectl get secret "${SECRET}" -n "${IRONIC_NS}" -o jsonpath='{.data.username}' | base64 -d)
 PASS=$(kubectl get secret "${SECRET}" -n "${IRONIC_NS}" -o jsonpath='{.data.password}' | base64 -d)
-kubectl -n "${IRONIC_NS}" apply -f - <<EOF
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ironic-credentials
-  namespace: ${IRONIC_NS}
-type: Opaque
-stringData:
-  username: "${USER}"
-  password: "${PASS}"
-EOF
+kubectl create secret generic ironic-credentials -n "${IRONIC_NS}" \
+  --from-literal=username="${USER}" --from-literal=password="${PASS}" \
+  --dry-run=client -o yaml | kubectl apply -f -
 
 kubectl -n "${IRONIC_NS}" patch deployment baremetal-operator-controller-manager \
   --patch-file="${ROOT_DIR}/hack/metal3-e2e/fixtures/bmo-auth-patch.yaml"

--- a/hack/metal3-e2e/setup-prov-net.sh
+++ b/hack/metal3-e2e/setup-prov-net.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Create node-local br-prov + Multus + NetworkAttachmentDefinition for PXE L2.
+set -euo pipefail
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+require_kind_node
+install_cni_plugins
+
+echo "==> installing Multus ${MULTUS_VERSION} (${MULTUS_MANIFEST})"
+kubectl apply -f "${MULTUS_MANIFEST}"
+kubectl -n kube-system rollout status daemonset/kube-multus-ds --timeout=180s
+
+echo "==> ensuring ${BR_NAME} on ${KIND_NODE} (${BR_CIDR})"
+docker exec "${KIND_NODE}" bash -c "
+  set -euo pipefail
+  if ! ip link show ${BR_NAME} >/dev/null 2>&1; then
+    ip link add ${BR_NAME} type bridge
+  fi
+  ip addr replace ${BR_CIDR} dev ${BR_NAME}
+  ip link set ${BR_NAME} up
+  # Allow IPA/dnsmasq traffic across the bridge.
+  iptables -C FORWARD -i ${BR_NAME} -j ACCEPT 2>/dev/null || iptables -I FORWARD -i ${BR_NAME} -j ACCEPT
+  iptables -C FORWARD -o ${BR_NAME} -j ACCEPT 2>/dev/null || iptables -I FORWARD -o ${BR_NAME} -j ACCEPT
+"
+
+echo "==> applying NetworkAttachmentDefinition ${NAD_NS}/${NAD_NAME}"
+envsubst '${NAD_NS} ${NAD_NAME} ${BR_NAME}' \
+  < "${ROOT_DIR}/hack/metal3-e2e/fixtures/nad-provisioning.yaml" | kubectl apply -f -
+
+echo "==> provisioning network ready (${BR_NAME} @ ${BR_CIDR}, NAD ${NAD_NS}/${NAD_NAME})"

--- a/pkg/resourcemanager/computersystem_resource.go
+++ b/pkg/resourcemanager/computersystem_resource.go
@@ -86,8 +86,13 @@ func NewComputerSystem(id, name string, powerState server.ResourcePowerState) *C
 			BootSourceOverrideTarget:  server.COMPUTERSYSTEMBOOTSOURCE_HDD,
 		},
 		OperatingSystem: fmt.Sprintf("/redfish/v1/Systems/%s/OperatingSystem", id),
+		// The VirtualMedia service is provided by the manager: the spec
+		// defines the collection only under /redfish/v1/Managers/{id}, and
+		// per the ComputerSystem CSDL this link points at the collection
+		// this system uses. A system-local .../VirtualMedia URI does not
+		// exist in the spec and would dangle.
 		VirtualMedia: server.OdataV4IdRef{
-			OdataId: fmt.Sprintf("/redfish/v1/Systems/%s/VirtualMedia", id),
+			OdataId: "/redfish/v1/Managers/BMC/VirtualMedia",
 		},
 		HostWatchdogTimer: server.ComputerSystemV1220WatchdogTimer{
 			FunctionEnabled: util.Ptr(false),

--- a/test/kind-config-metal3.yaml
+++ b/test/kind-config-metal3.yaml
@@ -1,0 +1,12 @@
+# Single-node Kind for Metal3/Ironic integration e2e.
+# Provisioning L2 is a node-local bridge (br-prov) + Multus, not an extra Docker network.
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    serializeImagePulls: false
+    maxParallelImagePulls: 10
+nodes:
+  - role: control-plane

--- a/test/metal3-e2e/provision_helpers_test.go
+++ b/test/metal3-e2e/provision_helpers_test.go
@@ -1,0 +1,378 @@
+package metal3e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+	"kubevirt.io/kubevirtbmc/test/util"
+)
+
+const (
+	provisionNS = "default"
+
+	// Fedora Cloud "Generic" is a hybrid BIOS/UEFI image; one qcow2 covers both
+	// BMH bootModes. The bootMode↔firmware coupling is IPA media (legacy ISO is
+	// BIOS-only; UEFI needs OVMF), not this user image.
+	defaultUserImageURL = "https://download.fedoraproject.org/pub/archive/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
+	defaultUserImageSum = "6205ae0c524b4d1816dbd3573ce29b5c44ed26c9fbc874fbe48c41c89dd0bac2"
+
+	cachedImageName = "metal3-user.qcow2"
+	provTimeout     = 60 * time.Minute
+
+	bootModeLegacy = "legacy"
+	bootModeUEFI   = "UEFI"
+)
+
+type provisionTarget struct {
+	Name       string
+	MAC        string
+	SecretName string
+	BMCName    string
+	VMName     string
+	RootDVName string
+	BMHName    string
+	Username   string
+	Password   string
+}
+
+func newProvisionTarget(prefix, mac string) provisionTarget {
+	// Root DV must not share the VM name: virtbmc InsertMedia creates the ISO
+	// DataVolume as <vmName>, so a blank root named <vmName> would collide.
+	return provisionTarget{
+		Name:       prefix,
+		MAC:        mac,
+		SecretName: prefix + "-bmc-secret",
+		BMCName:    prefix + "-bmc",
+		VMName:     prefix,
+		RootDVName: prefix + "-root",
+		BMHName:    prefix + "-bmh",
+		Username:   "admin",
+		Password:   "password",
+	}
+}
+
+func ensureCDIForProvision() {
+	By("ensuring CDI + DeclarativeHotplugVolumes (Ironic VirtualMedia → CDI)")
+	if !util.IsCDIInstalled() {
+		By("installing CDI")
+		Expect(util.InstallCDI()).To(Succeed())
+	} else {
+		By("CDI already installed")
+	}
+	By("patching Kind local-path StorageProfile with ReadWriteOnce (InsertMedia DV has no accessModes)")
+	Expect(util.EnsureDefaultStorageProfileAccessMode()).To(Succeed())
+	By("ensuring DeclarativeHotplugVolumes feature gate")
+	Expect(util.EnsureDeclarativeHotplugVolumes()).To(Succeed())
+}
+
+func ironicHTTPDPod() string {
+	out, err := exec.Command("kubectl", "-n", "baremetal-operator-system", "get", "pod",
+		"-l", "ironic.metal3.io/app=ironic-service",
+		"-o", "jsonpath={.items[0].metadata.name}").CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), string(out))
+	pod := strings.TrimSpace(string(out))
+	Expect(pod).NotTo(BeEmpty())
+	return pod
+}
+
+func cacheUserImageOnIronicHTTPD() (imageURL, checksum string) {
+	srcURL := os.Getenv("METAL3_USER_IMAGE_URL")
+	checksum = os.Getenv("METAL3_USER_IMAGE_CHECKSUM")
+	if srcURL == "" {
+		srcURL = defaultUserImageURL
+	}
+	if checksum == "" {
+		checksum = defaultUserImageSum
+	}
+
+	By("caching user qcow2 onto Ironic httpd (IPA on br-prov can reach BR_IP:6180)")
+	pod := ironicHTTPDPod()
+	check := exec.Command("kubectl", "-n", "baremetal-operator-system", "exec", pod, "-c", "httpd", "--",
+		"test", "-s", "/shared/html/images/"+cachedImageName)
+	if check.Run() != nil {
+		tmp := filepath.Join(os.TempDir(), cachedImageName)
+		if st, err := os.Stat(tmp); err != nil || st.Size() == 0 {
+			By("downloading user image to " + tmp)
+			cmd := exec.Command("curl", "-sfSL", "--retry", "3", "-o", tmp, srcURL)
+			cmd.Stdout = GinkgoWriter
+			cmd.Stderr = GinkgoWriter
+			Expect(cmd.Run()).To(Succeed(), "download user image from %s", srcURL)
+		} else {
+			By(fmt.Sprintf("reusing local cached image %s (%d bytes)", tmp, st.Size()))
+		}
+		By("kubectl cp image into ironic httpd pod")
+		Expect(exec.Command("kubectl", "-n", "baremetal-operator-system", "cp",
+			tmp, pod+":/shared/html/images/"+cachedImageName, "-c", "httpd").Run()).
+			To(Succeed(), "kubectl cp image into ironic httpd")
+	} else {
+		By("user image already present on ironic httpd")
+	}
+
+	brIP := os.Getenv("BR_IP")
+	if brIP == "" {
+		brIP = "172.22.0.1"
+	}
+	return fmt.Sprintf("http://%s:6180/images/%s", brIP, cachedImageName), checksum
+}
+
+func (t provisionTarget) cleanup(ctx context.Context) {
+	// Delete BMH first and wait while VirtualMachineBMC is still up. Otherwise
+	// Ironic's Redfish tear-down hits a dead ClusterIP, the node sticks in
+	// error, and the next BMH with the same name reuses it and hangs in preparing.
+	bmh := &unstructured.Unstructured{}
+	bmh.SetGroupVersionKind(bmhGVK)
+	bmh.SetName(t.BMHName)
+	bmh.SetNamespace(provisionNS)
+	_ = k8sClient.Delete(ctx, bmh)
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, client.ObjectKey{Namespace: provisionNS, Name: t.BMHName}, bmh)
+		return apierrors.IsNotFound(err)
+	}, testTimeout, testInterval).Should(BeTrue(), "BareMetalHost %s should be gone before deleting BMC", t.BMHName)
+
+	_ = k8sClient.Delete(ctx, &bmcv1.VirtualMachineBMC{ObjectMeta: metav1.ObjectMeta{Name: t.BMCName, Namespace: provisionNS}})
+	_ = k8sClient.Delete(ctx, &kubevirtv1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{Name: t.VMName, Namespace: provisionNS}})
+	_ = k8sClient.Delete(ctx, &cdiv1.DataVolume{ObjectMeta: metav1.ObjectMeta{Name: t.RootDVName, Namespace: provisionNS}})
+	// InsertMedia names the ISO DataVolume after the VM; drop leftovers from failed runs.
+	_ = k8sClient.Delete(ctx, &cdiv1.DataVolume{ObjectMeta: metav1.ObjectMeta{Name: t.VMName, Namespace: provisionNS}})
+	_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: t.SecretName, Namespace: provisionNS}})
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, client.ObjectKey{Namespace: provisionNS, Name: t.VMName}, &kubevirtv1.VirtualMachine{})
+		return apierrors.IsNotFound(err)
+	}, testTimeout, testInterval).Should(BeTrue())
+	for _, dvName := range []string{t.RootDVName, t.VMName} {
+		name := dvName
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKey{Namespace: provisionNS, Name: name}, &cdiv1.DataVolume{})
+			return apierrors.IsNotFound(err)
+		}, testTimeout, testInterval).Should(BeTrue(), "DataVolume %s should be gone", name)
+	}
+}
+
+func (t provisionTarget) createStoppedVMWithBMC(ctx context.Context, enableIPMI bool, bootMode string) string {
+	By(fmt.Sprintf("creating blank-disk VM (bootMode=%s) + VirtualMachineBMC for %s", bootMode, t.Name))
+	t.cleanup(ctx)
+
+	Expect(k8sClient.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: t.SecretName, Namespace: provisionNS},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{"username": t.Username, "password": t.Password},
+	})).To(Succeed())
+
+	Expect(k8sClient.Create(ctx, &cdiv1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: t.RootDVName, Namespace: provisionNS},
+		Spec: cdiv1.DataVolumeSpec{
+			PVC: &corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					// Fedora Cloud Generic virtual size is 5Gi; keep a small margin.
+					//$ qemu-img info Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+					//image: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+					//file format: qcow2
+					//virtual size: 5 GiB (5368709120 bytes)
+					//disk size: 469 MiB
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("6Gi")},
+				},
+			},
+			Source: &cdiv1.DataVolumeSource{Blank: &cdiv1.DataVolumeBlankImage{}},
+		},
+	})).To(Succeed())
+
+	runStrategy := kubevirtv1.RunStrategyManual
+	boot1, boot2 := uint(1), uint(2)
+	// Match VM firmware to BMH bootMode: Ironic legacy virtualmedia ISO is
+	// BIOS-only (OVMF → "DVD Not Found"); UEFI needs EFI with SecureBoot off.
+	var firmware *kubevirtv1.Firmware
+	if bootMode == bootModeUEFI {
+		secureBoot := false
+		firmware = &kubevirtv1.Firmware{
+			Bootloader: &kubevirtv1.Bootloader{
+				EFI: &kubevirtv1.EFI{SecureBoot: &secureBoot},
+			},
+		}
+	}
+	Expect(k8sClient.Create(ctx, &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.VMName,
+			Namespace: provisionNS,
+			Labels:    map[string]string{"app.kubernetes.io/part-of": "kubevirtbmc-metal3-e2e"},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			RunStrategy: &runStrategy,
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app.kubernetes.io/part-of": "kubevirtbmc-metal3-e2e"},
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{Cores: 2},
+						Resources: kubevirtv1.ResourceRequirements{
+							// IPA ramdisk needs headroom; 2Gi runs out of tmpfs
+							// ("No space left on device" writing /etc/udev/hwdb.bin).
+							Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+						},
+						Firmware: firmware,
+						Devices: kubevirtv1.Devices{
+							Disks: []kubevirtv1.Disk{
+								{
+									Name: "rootdisk",
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{Bus: kubevirtv1.DiskBusVirtio},
+									},
+									BootOrder: &boot1,
+								},
+								{
+									Name: "cdrom",
+									DiskDevice: kubevirtv1.DiskDevice{
+										CDRom: &kubevirtv1.CDRomTarget{Bus: kubevirtv1.DiskBusSATA},
+									},
+								},
+							},
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+									InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+										Masquerade: &kubevirtv1.InterfaceMasquerade{},
+									},
+								},
+								{
+									Name:       "provisioning",
+									MacAddress: t.MAC,
+									InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+										Bridge: &kubevirtv1.InterfaceBridge{},
+									},
+									BootOrder: &boot2,
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{Name: "default", NetworkSource: kubevirtv1.NetworkSource{Pod: &kubevirtv1.PodNetwork{}}},
+						{Name: "provisioning", NetworkSource: kubevirtv1.NetworkSource{
+							Multus: &kubevirtv1.MultusNetwork{NetworkName: "default/provisioning"},
+						}},
+					},
+					Volumes: []kubevirtv1.Volume{
+						{Name: "rootdisk", VolumeSource: kubevirtv1.VolumeSource{
+							DataVolume: &kubevirtv1.DataVolumeSource{Name: t.RootDVName},
+						}},
+						// No emptyDisk for cdrom: virtbmc InsertMedia appends a volume named
+						// after the CDROM disk; a placeholder would duplicate the name and be
+						// rejected by KubeVirt's virtualmachine-validator webhook.
+					},
+				},
+			},
+		},
+	})).To(Succeed())
+
+	bmc := &bmcv1.VirtualMachineBMC{
+		ObjectMeta: metav1.ObjectMeta{Name: t.BMCName, Namespace: provisionNS},
+		Spec: bmcv1.VirtualMachineBMCSpec{
+			VirtualMachineRef: &corev1.LocalObjectReference{Name: t.VMName},
+			AuthSecretRef:     &corev1.LocalObjectReference{Name: t.SecretName},
+		},
+	}
+	if enableIPMI {
+		enabled := true
+		bmc.Spec.IPMI = &bmcv1.IPMISpec{Enabled: &enabled}
+	}
+	Expect(k8sClient.Create(ctx, bmc)).To(Succeed())
+
+	var clusterIP string
+	Eventually(func(g Gomega) {
+		var cur bmcv1.VirtualMachineBMC
+		g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: provisionNS, Name: t.BMCName}, &cur)).To(Succeed())
+		g.Expect(cur.Status.ClusterIP).NotTo(BeEmpty())
+		clusterIP = cur.Status.ClusterIP
+	}, testTimeout, testInterval).Should(Succeed())
+	return clusterIP
+}
+
+func (t provisionTarget) createBMH(ctx context.Context, bmcAddress, imageURL, checksum, bootMode string) {
+	By(fmt.Sprintf("creating BareMetalHost %s (%s, bootMode=%s)", t.BMHName, bmcAddress, bootMode))
+	bmh := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "metal3.io/v1alpha1",
+		"kind":       "BareMetalHost",
+		"metadata": map[string]interface{}{
+			"name":      t.BMHName,
+			"namespace": provisionNS,
+			"annotations": map[string]interface{}{
+				"inspect.metal3.io": "disabled",
+			},
+			"labels": map[string]interface{}{
+				"kubevirtbmc.io/metal3-e2e": t.Name,
+			},
+		},
+		"spec": map[string]interface{}{
+			"online":                true,
+			"bootMode":              bootMode,
+			"bootMACAddress":        t.MAC,
+			"automatedCleaningMode": "disabled",
+			"bmc": map[string]interface{}{
+				"address":                        bmcAddress,
+				"credentialsName":                t.SecretName,
+				"disableCertificateVerification": true,
+			},
+			"rootDeviceHints": map[string]interface{}{
+				"deviceName": "/dev/vda",
+			},
+			"image": map[string]interface{}{
+				"url":          imageURL,
+				"checksum":     checksum,
+				"checksumType": "sha256",
+				"format":       "qcow2",
+			},
+		},
+	}}
+	bmh.SetGroupVersionKind(schema.GroupVersionKind{Group: "metal3.io", Version: "v1alpha1", Kind: "BareMetalHost"})
+	Expect(k8sClient.Create(ctx, bmh)).To(Succeed())
+}
+
+func waitBMHProvisioningState(ctx context.Context, name, want string) {
+	By("waiting for BareMetalHost " + name + " provisioning.state=" + want)
+	Eventually(func(g Gomega) {
+		bmh := &unstructured.Unstructured{}
+		bmh.SetGroupVersionKind(bmhGVK)
+		g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: provisionNS, Name: name}, bmh)).To(Succeed())
+		state, _, err := unstructured.NestedString(bmh.Object, "status", "provisioning", "state")
+		g.Expect(err).NotTo(HaveOccurred())
+		if state != want {
+			errType, _, _ := unstructured.NestedString(bmh.Object, "status", "errorType")
+			errMsg, _, _ := unstructured.NestedString(bmh.Object, "status", "errorMessage")
+			g.Expect(state).To(Equal(want), "errorType=%s errorMessage=%s", errType, errMsg)
+		}
+	}, provTimeout, 15*time.Second).Should(Succeed())
+}
+
+func waitGuestAgentConnected(ctx context.Context, vmName string) {
+	By("waiting for QEMU guest agent on " + vmName)
+	Eventually(func(g Gomega) {
+		var vmi kubevirtv1.VirtualMachineInstance
+		g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: provisionNS, Name: vmName}, &vmi)).To(Succeed())
+		g.Expect(vmi.Status.Phase).To(Equal(kubevirtv1.Running))
+		connected := false
+		for _, c := range vmi.Status.Conditions {
+			if c.Type == kubevirtv1.VirtualMachineInstanceAgentConnected && c.Status == corev1.ConditionTrue {
+				connected = true
+			}
+		}
+		g.Expect(connected).To(BeTrue())
+	}, provTimeout, 15*time.Second).Should(Succeed())
+}

--- a/test/metal3-e2e/provision_test.go
+++ b/test/metal3-e2e/provision_test.go
@@ -1,0 +1,147 @@
+package metal3e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ironicGVK = schema.GroupVersionKind{
+		Group:   "ironic.metal3.io",
+		Version: "v1alpha1",
+		Kind:    "Ironic",
+	}
+	bmhGVK = schema.GroupVersionKind{
+		Group:   "metal3.io",
+		Version: "v1alpha1",
+		Kind:    "BareMetalHost",
+	}
+)
+
+type provisionCase struct {
+	target     provisionTarget
+	enableIPMI bool
+	bootMode   string
+	bmcAddress func(bmcIP string) string
+}
+
+// redfishCase builds a BMH that talks Redfish. scheme is the Metal3 address
+// prefix and selects Ironic's boot interface, e.g.:
+//   - "redfish-virtualmedia" → InsertMedia ISO
+//   - "redfish"              → BootSourceOverrideTarget=Pxe (ipxe)
+//   - "redfish-uefihttp"     → UEFI HTTP Boot (future)
+func redfishCase(prefix, mac, bootMode, scheme string) provisionCase {
+	return provisionCase{
+		target:     newProvisionTarget(prefix, mac),
+		enableIPMI: false,
+		bootMode:   bootMode,
+		bmcAddress: func(ip string) string {
+			return fmt.Sprintf("%s+http://%s/redfish/v1/Systems/1", scheme, ip)
+		},
+	}
+}
+
+func ipmiProvisionCase(prefix, mac, bootMode string) provisionCase {
+	return provisionCase{
+		target:     newProvisionTarget(prefix, mac),
+		enableIPMI: true,
+		bootMode:   bootMode,
+		bmcAddress: func(ip string) string {
+			return fmt.Sprintf("ipmi://%s:623", ip)
+		},
+	}
+}
+
+var _ = Describe("Metal3 stack (IrSO + BMO)", func() {
+	It("has Ironic Ready and BareMetalHost CRD installed", func() {
+		ctx := context.Background()
+
+		By("waiting for Ironic CR Ready")
+		Eventually(func(g Gomega) {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(ironicGVK)
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+				Namespace: "baremetal-operator-system",
+				Name:      "ironic",
+			}, obj)).To(Succeed())
+			conds, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			ready := false
+			for _, c := range conds {
+				m, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if m["type"] == "Ready" && m["status"] == "True" {
+					ready = true
+				}
+			}
+			g.Expect(ready).To(BeTrue())
+		}, 10*time.Minute, testInterval).Should(Succeed())
+
+		By("checking BareMetalHost CRD exists")
+		cmd := exec.Command("kubectl", "get", "crd", "baremetalhosts.metal3.io", "-o", "name")
+		out, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), string(out))
+		Expect(string(out)).To(ContainSubstring("baremetalhosts.metal3.io"))
+
+		By("checking BMO deployment Available")
+		Eventually(func() string {
+			cmd := exec.Command("kubectl", "-n", "baremetal-operator-system",
+				"get", "deploy", "baremetal-operator-controller-manager",
+				"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return ""
+			}
+			return string(out)
+		}, testTimeout, testInterval).Should(Equal("True"))
+	})
+})
+
+// Environment prep (CDI, user image on Ironic httpd) lives in BeforeSuite
+// (suite_test.go); these are set there so every spec reports pure case time.
+var (
+	cachedImageURL string
+	cachedImageSum string
+)
+
+var _ = Describe("Metal3 BareMetalHost provision", Ordered, Label("metal3", "slow"), func() {
+	ctx := context.Background()
+
+	// protocol × bootMode. One Fedora Generic qcow2 covers both bootModes;
+	// VM firmware is matched to BMH bootMode (see createStoppedVMWithBMC).
+	// Cases run one-at-a-time and clean up after each so disk/RAM stay fit for
+	// GitHub-hosted runners (~14Gi free disk, ~7Gi RAM).
+	DescribeTable("provisions and verifies guest agent",
+		func(c provisionCase) {
+			DeferCleanup(func() {
+				if os.Getenv("KEEP_ENV") == envTrueValue {
+					_, _ = fmt.Fprintf(GinkgoWriter, "KEEP_ENV=true, skipping cleanup of %s\n", c.target.Name)
+					return
+				}
+				c.target.cleanup(ctx)
+			})
+			bmcIP := c.target.createStoppedVMWithBMC(ctx, c.enableIPMI, c.bootMode)
+			c.target.createBMH(ctx, c.bmcAddress(bmcIP), cachedImageURL, cachedImageSum, c.bootMode)
+			waitBMHProvisioningState(ctx, c.target.BMHName, "provisioned")
+			waitGuestAgentConnected(ctx, c.target.VMName)
+		},
+		Entry("redfish-virtualmedia / legacy", redfishCase("node-rfv-leg", "02:00:00:00:00:21", bootModeLegacy, "redfish-virtualmedia")),
+		Entry("redfish-virtualmedia / UEFI", redfishCase("node-rfv-uefi", "02:00:00:00:00:23", bootModeUEFI, "redfish-virtualmedia")),
+		Entry("redfish+PXE / legacy", redfishCase("node-rfp-leg", "02:00:00:00:00:25", bootModeLegacy, "redfish")),
+		Entry("redfish+PXE / UEFI", redfishCase("node-rfp-uefi", "02:00:00:00:00:26", bootModeUEFI, "redfish")),
+		Entry("ipmi+PXE / legacy", ipmiProvisionCase("node-ipmi-leg", "02:00:00:00:00:22", bootModeLegacy)),
+		Entry("ipmi+PXE / UEFI", ipmiProvisionCase("node-ipmi-uefi", "02:00:00:00:00:24", bootModeUEFI)),
+	)
+})

--- a/test/metal3-e2e/provnet_test.go
+++ b/test/metal3-e2e/provnet_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -114,12 +115,12 @@ var _ = Describe("provisioning network (br-prov + Multus)", Ordered, func() {
 
 		By("waiting for virtbmc agent pod Ready")
 		Eventually(func(g Gomega) {
-			var pod corev1.Pod
+			var deploy appsv1.Deployment
 			g.Expect(k8sClient.Get(ctx, client.ObjectKey{
 				Namespace: provNS,
 				Name:      provVMName + "-virtbmc",
-			}, &pod)).To(Succeed())
-			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+			}, &deploy)).To(Succeed())
+			g.Expect(deploy.Status.ReadyReplicas).To(BeNumerically(">=", 1))
 		}, testTimeout, testInterval).Should(Succeed())
 	})
 })

--- a/test/metal3-e2e/provnet_test.go
+++ b/test/metal3-e2e/provnet_test.go
@@ -1,0 +1,199 @@
+package metal3e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+)
+
+const (
+	provMAC     = "02:00:00:00:00:11"
+	provVMName  = "metal3-provnet-vm"
+	provBMCName = "metal3-provnet-bmc"
+	provSecret  = "metal3-provnet-secret"
+	provNS      = "default"
+)
+
+var _ = Describe("provisioning network (br-prov + Multus)", Ordered, func() {
+	ctx := context.Background()
+
+	cleanupProvnet := func() {
+		_ = k8sClient.Delete(ctx, &bmcv1.VirtualMachineBMC{
+			ObjectMeta: metav1.ObjectMeta{Name: provBMCName, Namespace: provNS},
+		})
+		_ = k8sClient.Delete(ctx, &kubevirtv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: provVMName, Namespace: provNS},
+		})
+		_ = k8sClient.Delete(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: provSecret, Namespace: provNS},
+		})
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKey{Namespace: provNS, Name: provVMName}, &kubevirtv1.VirtualMachine{})
+			return apierrors.IsNotFound(err)
+		}, testTimeout, testInterval).Should(BeTrue())
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKey{Namespace: provNS, Name: provSecret}, &corev1.Secret{})
+			return apierrors.IsNotFound(err)
+		}, testTimeout, testInterval).Should(BeTrue())
+	}
+
+	// KEEP_ENV leaves resources for debugging; always wipe before create so re-runs don't hit AlreadyExists.
+	BeforeAll(cleanupProvnet)
+
+	AfterAll(func() {
+		if os.Getenv("KEEP_ENV") == envTrueValue {
+			_, _ = fmt.Fprintf(GinkgoWriter, "KEEP_ENV=true, skipping provnet cleanup\n")
+			return
+		}
+		cleanupProvnet()
+	})
+
+	It("boots a VM on Multus/br-prov and exposes BMC ClusterIP", func() {
+		By("creating BMC credentials")
+		Expect(k8sClient.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: provSecret, Namespace: provNS},
+			Type:       corev1.SecretTypeOpaque,
+			StringData: map[string]string{"username": "admin", "password": "password"},
+		})).To(Succeed())
+
+		By("creating VM with Multus provisioning NIC (RunStrategy Always)")
+		Expect(k8sClient.Create(ctx, minimalProvVM(provVMName, provNS, provMAC))).To(Succeed())
+
+		By("creating VirtualMachineBMC with IPMI enabled")
+		enabled := true
+		Expect(k8sClient.Create(ctx, &bmcv1.VirtualMachineBMC{
+			ObjectMeta: metav1.ObjectMeta{Name: provBMCName, Namespace: provNS},
+			Spec: bmcv1.VirtualMachineBMCSpec{
+				VirtualMachineRef: &corev1.LocalObjectReference{Name: provVMName},
+				AuthSecretRef:     &corev1.LocalObjectReference{Name: provSecret},
+				IPMI:              &bmcv1.IPMISpec{Enabled: &enabled},
+			},
+		})).To(Succeed())
+
+		By("waiting for VirtualMachineBMC Ready + ClusterIP")
+		Eventually(func(g Gomega) {
+			var bmc bmcv1.VirtualMachineBMC
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: provNS, Name: provBMCName}, &bmc)).To(Succeed())
+			g.Expect(bmc.Status.ClusterIP).NotTo(BeEmpty())
+			ready := false
+			for _, c := range bmc.Status.Conditions {
+				if c.Type == bmcv1.ConditionReady && c.Status == metav1.ConditionTrue {
+					ready = true
+				}
+			}
+			g.Expect(ready).To(BeTrue())
+		}, testTimeout, testInterval).Should(Succeed())
+
+		By("waiting for VMI Running with provisioning MAC")
+		Eventually(func(g Gomega) {
+			var vmi kubevirtv1.VirtualMachineInstance
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: provNS, Name: provVMName}, &vmi)).To(Succeed())
+			g.Expect(vmi.Status.Phase).To(Equal(kubevirtv1.Running))
+			found := false
+			for _, iface := range vmi.Status.Interfaces {
+				if iface.MAC == provMAC || iface.Name == "provisioning" {
+					found = true
+					if iface.MAC != "" {
+						g.Expect(iface.MAC).To(Equal(provMAC))
+					}
+				}
+			}
+			g.Expect(found).To(BeTrue(), "expected provisioning interface on VMI status")
+		}, testTimeout, testInterval).Should(Succeed())
+
+		By("waiting for virtbmc agent pod Ready")
+		Eventually(func(g Gomega) {
+			var pod corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+				Namespace: provNS,
+				Name:      provVMName + "-virtbmc",
+			}, &pod)).To(Succeed())
+			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+		}, testTimeout, testInterval).Should(Succeed())
+	})
+})
+
+func minimalProvVM(name, namespace, mac string) *kubevirtv1.VirtualMachine {
+	secureBoot := false
+	runStrategy := kubevirtv1.RunStrategyAlways
+	boot1, boot2 := uint(1), uint(2)
+	return &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app.kubernetes.io/part-of": "kubevirtbmc-metal3-e2e"},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			RunStrategy: &runStrategy,
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app.kubernetes.io/part-of": "kubevirtbmc-metal3-e2e"},
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Resources: kubevirtv1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+						Firmware: &kubevirtv1.Firmware{
+							Bootloader: &kubevirtv1.Bootloader{
+								EFI: &kubevirtv1.EFI{SecureBoot: &secureBoot},
+							},
+						},
+						Devices: kubevirtv1.Devices{
+							Disks: []kubevirtv1.Disk{{
+								Name: "rootdisk",
+								DiskDevice: kubevirtv1.DiskDevice{
+									Disk: &kubevirtv1.DiskTarget{Bus: kubevirtv1.DiskBusVirtio},
+								},
+								BootOrder: &boot1,
+							}},
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+									InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+										Masquerade: &kubevirtv1.InterfaceMasquerade{},
+									},
+								},
+								{
+									Name:       "provisioning",
+									MacAddress: mac,
+									InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+										Bridge: &kubevirtv1.InterfaceBridge{},
+									},
+									BootOrder: &boot2,
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{Name: "default", NetworkSource: kubevirtv1.NetworkSource{Pod: &kubevirtv1.PodNetwork{}}},
+						{Name: "provisioning", NetworkSource: kubevirtv1.NetworkSource{
+							Multus: &kubevirtv1.MultusNetwork{NetworkName: "default/provisioning"},
+						}},
+					},
+					Volumes: []kubevirtv1.Volume{{
+						Name: "rootdisk",
+						VolumeSource: kubevirtv1.VolumeSource{
+							ContainerDisk: &kubevirtv1.ContainerDiskSource{
+								Image: "quay.io/containerdisks/fedora:latest",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}

--- a/test/metal3-e2e/suite_test.go
+++ b/test/metal3-e2e/suite_test.go
@@ -1,0 +1,150 @@
+package metal3e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+	"kubevirt.io/kubevirtbmc/test/util"
+)
+
+const (
+	metal3ClusterName = "kvbmc-metal3-e2e"
+	testTimeout       = 5 * time.Minute
+	testInterval      = 2 * time.Second
+	envTrueValue      = "true"
+)
+
+var (
+	nadGVK = schema.GroupVersionKind{
+		Group:   "k8s.cni.cncf.io",
+		Version: "v1",
+		Kind:    "NetworkAttachmentDefinition",
+	}
+
+	skipKubeVirtInstall    = os.Getenv("KUBEVIRT_INSTALL_SKIP") == "true"
+	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
+
+	repo = func() string {
+		if r := os.Getenv("REPO"); r != "" {
+			return r
+		}
+		return "kubevirtbmc"
+	}()
+	tag = func() string {
+		if t := os.Getenv("TAG"); t != "" {
+			return t
+		}
+		return "dev"
+	}()
+	controllerManagerImage = fmt.Sprintf("%s/virtbmc-controller:%s", repo, tag)
+	agentImage             = fmt.Sprintf("%s/virtbmc:%s", repo, tag)
+
+	config    *rest.Config
+	k8sClient client.Client
+)
+
+func TestMetal3E2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metal3/Ironic integration E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	if os.Getenv("KIND_CLUSTER") == "" {
+		Expect(os.Setenv("KIND_CLUSTER", metal3ClusterName)).To(Succeed())
+	}
+
+	By("loading controller/agent images into Kind")
+	Expect(util.LoadImageToKindClusterWithName(controllerManagerImage, agentImage)).To(Succeed())
+
+	By("creating clients")
+	var err error
+	config, err = clientConfig()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(kubevirtv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(bmcv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(cdiv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	k8sClient, err = client.New(config, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	if !skipKubeVirtInstall {
+		By("installing KubeVirt if needed")
+		if !util.IsKubeVirtInstalled() {
+			Expect(util.InstallKubeVirt()).To(Succeed())
+		}
+	}
+
+	if !skipCertManagerInstall {
+		By("installing cert-manager if needed")
+		if !util.IsCertManagerCRDsInstalled() {
+			Expect(util.InstallCertManager()).To(Succeed())
+		}
+	}
+
+	// CDI + the DeclarativeHotplugVolumes gate back Ironic VirtualMedia → CDI;
+	// same "cluster prerequisite" tier as KubeVirt/cert-manager above.
+	ensureCDIForProvision()
+
+	By("deploying kubevirtbmc controller")
+	cmd := exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", controllerManagerImage))
+	_, err = util.Run(cmd)
+	Expect(err).NotTo(HaveOccurred())
+
+	ctx := context.Background()
+	util.WaitForControllerManagerReady(ctx, k8sClient, testTimeout, testInterval)
+	util.WaitForWebhookServiceReady(ctx, k8sClient, testTimeout, testInterval)
+	util.WaitForWebhookEndpointSlicesReady(ctx, k8sClient, testTimeout, testInterval)
+	time.Sleep(util.WebhookRegistrationDelay)
+
+	By("requiring Multus NetworkAttachmentDefinition from metal3-e2e-setup")
+	Eventually(func() error {
+		nad := &unstructured.Unstructured{}
+		nad.SetGroupVersionKind(nadGVK)
+		return k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "provisioning"}, nad)
+	}, testTimeout, testInterval).Should(Succeed(),
+		"NAD default/provisioning missing; run: make metal3-e2e-setup")
+
+	// Same tier as the NAD above: Ironic httpd comes from metal3-e2e-setup.
+	// Idempotent (cached on the httpd pod and in os.TempDir), so rerunning a
+	// suite against a warm cluster costs nothing here.
+	cachedImageURL, cachedImageSum = cacheUserImageOnIronicHTTPD()
+})
+
+var _ = AfterSuite(func() {
+	if os.Getenv("KEEP_ENV") == envTrueValue {
+		_, _ = fmt.Fprintf(GinkgoWriter, "KEEP_ENV=true, skipping teardown\n")
+		return
+	}
+	By("undeploying kubevirtbmc controller")
+	cmd := exec.Command("make", "undeploy")
+	if _, err := util.Run(cmd); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: undeploy failed: %v\n", err)
+	}
+	// Keep cert-manager / KubeVirt / Metal3 across runs; use make metal3-e2e-teardown to wipe.
+})
+
+func clientConfig() (*rest.Config, error) {
+	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	return clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+}

--- a/test/util/bmc_client.go
+++ b/test/util/bmc_client.go
@@ -1,0 +1,229 @@
+package util
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	RedfishClientPodName = "redfish-client"
+	IPMIToolPodName      = "ipmitool"
+	CurlImage            = "curlimages/curl:latest"
+	IPMIToolImage        = "kubevirtbmc/ipmitool:latest" // ipmitool v1.8.19
+	helperPodTimeout     = 180 * time.Second
+	helperPodInterval    = 250 * time.Millisecond
+	sleepDuration        = "999999999"
+)
+
+type ExecOptions struct {
+	Namespace     string
+	PodName       string
+	ContainerName string
+	Command       []string
+}
+
+func ExecInPod(ctx context.Context, cfg *rest.Config, clientset *kubernetes.Clientset, opts ExecOptions) (stdout, stderr string, err error) {
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(opts.Namespace).
+		Name(opts.PodName).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: opts.ContainerName,
+			Command:   opts.Command,
+			Stdout:    true,
+			Stderr:    true,
+		}, kubescheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
+	if err != nil {
+		return "", "", fmt.Errorf("creating SPDY executor: %w", err)
+	}
+
+	var outBuf, errBuf bytes.Buffer
+	if err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &outBuf,
+		Stderr: &errBuf,
+	}); err != nil {
+		return outBuf.String(), errBuf.String(), fmt.Errorf("exec stream: %w", err)
+	}
+	return outBuf.String(), errBuf.String(), nil
+}
+
+func CreateRedfishClientPod(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: RedfishClientPodName, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:    "curl",
+				Image:   CurlImage,
+				Command: []string{"sleep", sleepDuration},
+			}},
+		},
+	}
+	_, err := clientset.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create redfish-client pod: %w", err)
+	}
+	Eventually(func() bool {
+		p, getErr := clientset.CoreV1().Pods(namespace).Get(ctx, RedfishClientPodName, metav1.GetOptions{})
+		if getErr != nil {
+			return false
+		}
+		return p.Status.Phase == corev1.PodRunning
+	}, helperPodTimeout, helperPodInterval).Should(BeTrue(), "redfish-client pod should reach Running")
+	return nil
+}
+
+func CreateIPMIToolPod(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: IPMIToolPodName, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:    "ipmitool",
+				Image:   IPMIToolImage,
+				Command: []string{"sleep", sleepDuration},
+			}},
+		},
+	}
+	_, err := clientset.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create ipmitool pod: %w", err)
+	}
+	Eventually(func() bool {
+		p, getErr := clientset.CoreV1().Pods(namespace).Get(ctx, IPMIToolPodName, metav1.GetOptions{})
+		if getErr != nil {
+			return false
+		}
+		return p.Status.Phase == corev1.PodRunning
+	}, helperPodTimeout, helperPodInterval).Should(BeTrue(), "ipmitool pod should reach Running")
+	return nil
+}
+
+func RunCurlInCluster(ctx context.Context, cfg *rest.Config, namespace string, args ...string) (stdout, stderr string, err error) {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return "", "", fmt.Errorf("building clientset: %w", err)
+	}
+	if err := CreateRedfishClientPod(ctx, clientset, namespace); err != nil {
+		return "", "", err
+	}
+	cmd := append([]string{"curl"}, args...)
+	return ExecInPod(ctx, cfg, clientset, ExecOptions{
+		Namespace:     namespace,
+		PodName:       RedfishClientPodName,
+		ContainerName: "curl",
+		Command:       cmd,
+	})
+}
+
+type RedfishRequest struct {
+	BaseURL    string
+	Method     string
+	Path       string
+	Body       string
+	Username   string
+	Password   string
+	XAuthToken string
+}
+
+func RunCurlRedfish(ctx context.Context, cfg *rest.Config, namespace string, r RedfishRequest) (string, error) {
+	url := r.BaseURL
+	if r.Path != "" {
+		url = strings.TrimSuffix(r.BaseURL, "/") + r.Path
+	}
+	args := []string{"--connect-timeout", "5", "--max-time", "15", "-i", "-L", "-X", r.Method}
+	if r.XAuthToken != "" {
+		args = append(args, "-H", "X-Auth-Token: "+r.XAuthToken)
+	} else if r.Username != "" && r.Password != "" {
+		args = append(args, "-u", r.Username+":"+r.Password)
+	}
+	if r.Body != "" {
+		args = append(args, "-H", "Content-Type: application/json", "-d", r.Body)
+	}
+	args = append(args, url)
+
+	out, _, err := RunCurlInCluster(ctx, cfg, namespace, args...)
+	return out, err
+}
+
+func CreateRedfishSession(ctx context.Context, cfg *rest.Config, namespace, baseURL, username, password string) (token string, err error) {
+	body := fmt.Sprintf(`{"UserName":"%s","Password":"%s"}`, username, password)
+	out, err := RunCurlRedfish(ctx, cfg, namespace, RedfishRequest{
+		BaseURL:  baseURL,
+		Method:   "POST",
+		Path:     "/SessionService/Sessions",
+		Body:     body,
+		Username: username,
+		Password: password,
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if idx := strings.Index(line, ":"); idx >= 0 && strings.EqualFold(strings.TrimSpace(line[:idx]), "X-Auth-Token") {
+			return strings.TrimSpace(line[idx+1:]), nil
+		}
+	}
+	return "", fmt.Errorf("X-Auth-Token not found in session response")
+}
+
+type IPMIRequest struct {
+	ServiceHost string
+	Username    string
+	Password    string
+	Interface   string // "lan" or "lanplus"; defaults to "lanplus"
+	RetryCount  int    // when > 0, passes -R to ipmitool (retry count)
+	Args        []string
+}
+
+func BuildIPMICommand(r IPMIRequest) []string {
+	iface := r.Interface
+	if iface == "" {
+		iface = "lanplus"
+	}
+	cmd := []string{"ipmitool", "-I", iface, "-U", r.Username, "-P", r.Password, "-H", r.ServiceHost}
+	if r.RetryCount > 0 {
+		cmd = append(cmd, "-R", strconv.Itoa(r.RetryCount))
+	}
+	return append(cmd, r.Args...)
+}
+
+func RunIPMIInCluster(ctx context.Context, cfg *rest.Config, namespace string, r IPMIRequest) (stdout, stderr string, err error) {
+	stdout, stderr, _, err = RunIPMIInClusterTimed(ctx, cfg, namespace, r)
+	return stdout, stderr, err
+}
+
+func RunIPMIInClusterTimed(ctx context.Context, cfg *rest.Config, namespace string, r IPMIRequest) (stdout, stderr string, elapsed time.Duration, err error) {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("building clientset: %w", err)
+	}
+	if err := CreateIPMIToolPod(ctx, clientset, namespace); err != nil {
+		return "", "", 0, err
+	}
+	start := time.Now()
+	stdout, stderr, err = ExecInPod(ctx, cfg, clientset, ExecOptions{
+		Namespace:     namespace,
+		PodName:       IPMIToolPodName,
+		ContainerName: "ipmitool",
+		Command:       BuildIPMICommand(r),
+	})
+	return stdout, stderr, time.Since(start), err
+}

--- a/test/util/e2e_resources.go
+++ b/test/util/e2e_resources.go
@@ -40,10 +40,6 @@ func AgentServiceKey(namespace string) types.NamespacedName {
 	return types.NamespacedName{Name: E2EAgentDeploymentName, Namespace: namespace}
 }
 
-func AgentPodKey(namespace string) types.NamespacedName {
-	return types.NamespacedName{Name: E2EAgentDeploymentName, Namespace: namespace}
-}
-
 var agentPodLabels = client.MatchingLabels{
 	bmcv1.VirtualMachineBMCNameLabel: E2EBMCName,
 	bmcv1.VMNameLabel:                E2EVMName,

--- a/test/util/helper.go
+++ b/test/util/helper.go
@@ -14,7 +14,8 @@ import (
 
 const (
 	certManagerURLFmt      = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
-	kubeVirtVersion        = "v1.8.4"
+	defaultKubeVirtVersion = "v1.8.4"
+	defaultCDIVersion      = "v1.65.0"
 	kubeVirtOperatorURLFmt = "https://github.com/kubevirt/kubevirt/releases/download/%s/kubevirt-operator.yaml"
 	kubeVirtCRURLFmt       = "https://github.com/kubevirt/kubevirt/releases/download/%s/kubevirt-cr.yaml"
 )
@@ -22,6 +23,22 @@ const (
 var (
 	certManagerVersion = os.Getenv("CERT_MANAGER_VERSION")
 )
+
+// kubeVirtInstallVersion prefers KUBEVIRT_VERSION from the Makefile / env.
+func kubeVirtInstallVersion() string {
+	if v := os.Getenv("KUBEVIRT_VERSION"); v != "" {
+		return v
+	}
+	return defaultKubeVirtVersion
+}
+
+// cdiInstallVersion prefers CDI_VERSION from the Makefile / env.
+func cdiInstallVersion() string {
+	if v := os.Getenv("CDI_VERSION"); v != "" {
+		return v
+	}
+	return defaultCDIVersion
+}
 
 func warnError(err error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: %v\n", err)
@@ -102,6 +119,74 @@ func VirtualMediaPrerequisitesMet() bool {
 	return IsCDIInstalled() && HasDeclarativeHotplugVolumesEnabled()
 }
 
+func InstallCDI() error {
+	version := cdiInstallVersion()
+	if !strings.HasPrefix(version, "v") || strings.Contains(version, "<") {
+		return fmt.Errorf("invalid CDI version %q", version)
+	}
+	_, _ = fmt.Fprintf(GinkgoWriter, "Installing CDI %s\n", version)
+
+	operatorURL := fmt.Sprintf("https://github.com/kubevirt/containerized-data-importer/releases/download/%s/cdi-operator.yaml", version)
+	if _, err := Run(exec.Command("kubectl", "apply", "-f", operatorURL)); err != nil {
+		return fmt.Errorf("apply CDI operator: %w", err)
+	}
+	crURL := fmt.Sprintf("https://github.com/kubevirt/containerized-data-importer/releases/download/%s/cdi-cr.yaml", version)
+	if _, err := Run(exec.Command("kubectl", "apply", "-f", crURL)); err != nil {
+		return fmt.Errorf("apply CDI CR: %w", err)
+	}
+
+	Eventually(func() (string, error) {
+		cmd := exec.Command("kubectl", "get", "cdi", "cdi", "-n", "cdi",
+			"-o", "jsonpath={.status.phase}", "--ignore-not-found")
+		out, err := Run(cmd)
+		return strings.TrimSpace(out), err
+	}, "5m", "5s").Should(Equal("Deployed"), "CDI should reach Deployed phase")
+	return nil
+}
+
+// EnsureDefaultStorageProfileAccessMode patches the default StorageProfile so CDI
+// DataVolumes that only set storage.size (e.g. virtbmc InsertMedia) can bind on
+// Kind local-path, whose provisioner is unrecognized and leaves claimPropertySets empty.
+func EnsureDefaultStorageProfileAccessMode() error {
+	patch := `{"spec":{"claimPropertySets":[{"accessModes":["ReadWriteOnce"],"volumeMode":"Filesystem"}]}}`
+	Eventually(func() error {
+		_, err := Run(exec.Command("kubectl", "get", "storageprofile", "standard"))
+		return err
+	}, "2m", "2s").Should(Succeed(), "StorageProfile standard should exist after CDI is Deployed")
+
+	out, err := Run(exec.Command("kubectl", "patch", "storageprofile", "standard",
+		"--type=merge", "-p", patch))
+	if err != nil {
+		return fmt.Errorf("patch StorageProfile standard: %w (%s)", err, out)
+	}
+	return nil
+}
+
+func EnsureDeclarativeHotplugVolumes() error {
+	if HasDeclarativeHotplugVolumesEnabled() {
+		return nil
+	}
+	cmd := exec.Command("kubectl", "patch", "kubevirt", "kubevirt", "-n", "kubevirt", "--type=json", "-p",
+		`[{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"DeclarativeHotplugVolumes"}]`)
+	if _, err := Run(cmd); err != nil {
+		// featureGates may be missing; merge-patch a full developerConfiguration
+		cmd = exec.Command("kubectl", "patch", "kubevirt", "kubevirt", "-n", "kubevirt", "--type=merge", "-p",
+			`{"spec":{"configuration":{"developerConfiguration":{"featureGates":["DeclarativeHotplugVolumes"]}}}}`)
+		if _, err2 := Run(cmd); err2 != nil {
+			return fmt.Errorf("enable DeclarativeHotplugVolumes: %w (merge fallback: %v)", err, err2)
+		}
+	}
+	Eventually(HasDeclarativeHotplugVolumesEnabled, "2m", "5s").Should(BeTrue())
+	// Patching the KubeVirt CR restarts virt-api; creating VMs before it is back
+	// hits virtualmachines-mutator with connection refused.
+	Eventually(func() error {
+		_, err := Run(exec.Command("kubectl", "-n", "kubevirt", "rollout", "status", "deploy/virt-api", "--timeout=60s"))
+		return err
+	}, "5m", "5s").Should(Succeed(), "virt-api should be Available after feature-gate patch")
+	Eventually(IsKubeVirtInstalled, "3m", "5s").Should(BeTrue(), "KubeVirt should return to Deployed")
+	return nil
+}
+
 func IsKubeVirtInstalled() bool {
 	cmd := exec.Command("kubectl", "get", "kubevirt", "kubevirt", "-n", "kubevirt",
 		"-o", "jsonpath={.status.phase}", "--ignore-not-found")
@@ -113,13 +198,15 @@ func IsKubeVirtInstalled() bool {
 }
 
 func InstallKubeVirt() error {
-	operatorURL := fmt.Sprintf(kubeVirtOperatorURLFmt, kubeVirtVersion)
+	version := kubeVirtInstallVersion()
+	_, _ = fmt.Fprintf(GinkgoWriter, "Installing KubeVirt %s\n", version)
+	operatorURL := fmt.Sprintf(kubeVirtOperatorURLFmt, version)
 	cmd := exec.Command("kubectl", "apply", "-f", operatorURL)
 	if _, err := Run(cmd); err != nil {
 		return fmt.Errorf("apply KubeVirt operator: %w", err)
 	}
 
-	crURL := fmt.Sprintf(kubeVirtCRURLFmt, kubeVirtVersion)
+	crURL := fmt.Sprintf(kubeVirtCRURLFmt, version)
 	cmd = exec.Command("kubectl", "apply", "-f", crURL)
 	if _, err := Run(cmd); err != nil {
 		return fmt.Errorf("apply KubeVirt CR: %w", err)
@@ -215,7 +302,7 @@ func getProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	for _, suffix := range []string{"/test/virtbmc-controller", "/test/virtbmc-agent"} {
+	for _, suffix := range []string{"/test/virtbmc-controller", "/test/virtbmc-agent", "/test/metal3-e2e"} {
 		if idx := strings.Index(wd, suffix); idx != -1 {
 			return wd[:idx], nil
 		}

--- a/test/virtbmc-agent/agent_helpers.go
+++ b/test/virtbmc-agent/agent_helpers.go
@@ -1,12 +1,9 @@
 package virtbmcagent
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	kvclient "kubevirt.io/client-go/kubevirt"
@@ -17,15 +14,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
-	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/remotecommand"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+	"kubevirt.io/kubevirtbmc/test/util"
 )
 
 const (
@@ -35,20 +30,19 @@ const (
 	agentSecretName     = "bmc-credentials-secret"
 	issue191DiskName    = "oneshot-conflict-disk"
 	issue191RemovedDisk = "oneshot-removed-disk"
-	curlImage           = "curlimages/curl:latest"
-	ipmitoolImage       = "kubevirtbmc/ipmitool:latest" // ipmitool v1.8.19
 	agentTestTimeout    = 60 * time.Second
 	agentTestInterval   = 250 * time.Millisecond
 	agentDeploymentName = "testvm-virtbmc"
 	// suiteInitTimeout covers container disk image pull during suite setup.
 	suiteInitTimeout     = 180 * time.Second
 	vmPowerStatusTimeout = 120 * time.Second
-	helperPodTimeout     = 180 * time.Second
 
-	redfishClientPodName = "redfish-client"
-	ipmitoolPodName      = "ipmitool"
-	sleepDuration        = "999999999"
+	redfishClientPodName = util.RedfishClientPodName
+	ipmitoolPodName      = util.IPMIToolPodName
 )
+
+type RedfishRequest = util.RedfishRequest
+type IPMIRequest = util.IPMIRequest
 
 type agentTestEnv struct {
 	VM             *kubevirtv1.VirtualMachine
@@ -529,213 +523,6 @@ func waitForAgentDeploymentReady(ctx context.Context, k8sClient client.Client, n
 			deployment.Status.ReadyReplicas >= desiredReplicas &&
 			deployment.Status.AvailableReplicas >= desiredReplicas
 	}, agentTestTimeout, agentTestInterval).Should(BeTrue(), "agent deployment %q should become ready", deploymentName)
-}
-
-func CreateRedfishClientPod(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: redfishClientPodName, Namespace: namespace},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:    "curl",
-					Image:   curlImage,
-					Command: []string{"sleep", sleepDuration},
-				},
-			},
-		},
-	}
-	_, err := clientset.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("create redfish-client pod: %w", err)
-	}
-	Eventually(func() bool {
-		p, getErr := clientset.CoreV1().Pods(namespace).Get(ctx, redfishClientPodName, metav1.GetOptions{})
-		if getErr != nil {
-			return false
-		}
-		return p.Status.Phase == corev1.PodRunning
-	}, helperPodTimeout, agentTestInterval).Should(BeTrue(), "redfish-client pod should reach Running")
-	return nil
-}
-
-func CreateIPMIToolPod(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: ipmitoolPodName, Namespace: namespace},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:    "ipmitool",
-					Image:   ipmitoolImage,
-					Command: []string{"sleep", sleepDuration},
-				},
-			},
-		},
-	}
-	_, err := clientset.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("create ipmitool pod: %w", err)
-	}
-	Eventually(func() bool {
-		p, getErr := clientset.CoreV1().Pods(namespace).Get(ctx, ipmitoolPodName, metav1.GetOptions{})
-		if getErr != nil {
-			return false
-		}
-		return p.Status.Phase == corev1.PodRunning
-	}, helperPodTimeout, agentTestInterval).Should(BeTrue(), "ipmitool pod should reach Running")
-	return nil
-}
-
-type execOptions struct {
-	Namespace     string
-	PodName       string
-	ContainerName string
-	Command       []string
-}
-
-func execInPod(ctx context.Context, cfg *rest.Config, clientset *kubernetes.Clientset, opts execOptions) (stdout, stderr string, err error) {
-	req := clientset.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Namespace(opts.Namespace).
-		Name(opts.PodName).
-		SubResource("exec").
-		VersionedParams(&corev1.PodExecOptions{
-			Container: opts.ContainerName,
-			Command:   opts.Command,
-			Stdout:    true,
-			Stderr:    true,
-		}, kubescheme.ParameterCodec)
-
-	executor, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
-	if err != nil {
-		return "", "", fmt.Errorf("creating SPDY executor: %w", err)
-	}
-
-	var outBuf, errBuf bytes.Buffer
-	if err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
-		Stdout: &outBuf,
-		Stderr: &errBuf,
-	}); err != nil {
-		return outBuf.String(), errBuf.String(), fmt.Errorf("exec stream: %w", err)
-	}
-
-	return outBuf.String(), errBuf.String(), nil
-}
-
-func runCurlInCluster(ctx context.Context, cfg *rest.Config, namespace string, args ...string) (stdout, stderr string, err error) {
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return "", "", fmt.Errorf("building clientset: %w", err)
-	}
-	if err := CreateRedfishClientPod(ctx, clientset, namespace); err != nil {
-		return "", "", err
-	}
-	cmd := append([]string{"curl"}, args...)
-	return execInPod(ctx, cfg, clientset, execOptions{
-		Namespace:     namespace,
-		PodName:       redfishClientPodName,
-		ContainerName: "curl",
-		Command:       cmd,
-	})
-}
-
-type RedfishRequest struct {
-	BaseURL    string
-	Method     string
-	Path       string
-	Body       string
-	Username   string
-	Password   string
-	XAuthToken string
-}
-
-func runCurlRedfish(ctx context.Context, cfg *rest.Config, namespace string, r RedfishRequest) (string, error) {
-	url := r.BaseURL
-	if r.Path != "" {
-		url = strings.TrimSuffix(r.BaseURL, "/") + r.Path
-	}
-	args := []string{"--connect-timeout", "5", "--max-time", "15", "-i", "-L", "-X", r.Method}
-	if r.XAuthToken != "" {
-		args = append(args, "-H", "X-Auth-Token: "+r.XAuthToken)
-	} else if r.Username != "" && r.Password != "" {
-		args = append(args, "-u", r.Username+":"+r.Password)
-	}
-	if r.Body != "" {
-		args = append(args, "-H", "Content-Type: application/json", "-d", r.Body)
-	}
-	args = append(args, url)
-
-	out, _, err := runCurlInCluster(ctx, cfg, namespace, args...)
-	return out, err
-}
-
-func CreateRedfishSession(ctx context.Context, cfg *rest.Config, namespace, baseURL, username, password string) (token string, err error) {
-	body := fmt.Sprintf(`{"UserName":"%s","Password":"%s"}`, username, password)
-	out, err := runCurlRedfish(ctx, cfg, namespace, RedfishRequest{
-		BaseURL:  baseURL,
-		Method:   "POST",
-		Path:     "/SessionService/Sessions",
-		Body:     body,
-		Username: username,
-		Password: password,
-	})
-	if err != nil {
-		return "", err
-	}
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimRight(line, "\r")
-		if idx := strings.Index(line, ":"); idx >= 0 && strings.EqualFold(strings.TrimSpace(line[:idx]), "X-Auth-Token") {
-			token = strings.TrimSpace(line[idx+1:])
-			return token, nil
-		}
-	}
-	return "", fmt.Errorf("X-Auth-Token not found in session response")
-}
-
-type IPMIRequest struct {
-	ServiceHost string
-	Username    string
-	Password    string
-	Interface   string // "lan" or "lanplus"; defaults to "lanplus"
-	RetryCount  int    // when > 0, passes -R to ipmitool (retry count)
-	Args        []string
-}
-
-func buildIPMICommand(r IPMIRequest) []string {
-	iface := r.Interface
-	if iface == "" {
-		iface = "lanplus"
-	}
-	cmd := []string{"ipmitool", "-I", iface, "-U", r.Username, "-P", r.Password, "-H", r.ServiceHost}
-	if r.RetryCount > 0 {
-		cmd = append(cmd, "-R", strconv.Itoa(r.RetryCount))
-	}
-	return append(cmd, r.Args...)
-}
-
-func runIPMIInCluster(ctx context.Context, cfg *rest.Config, namespace string, r IPMIRequest) (stdout, stderr string, err error) {
-	stdout, stderr, _, err = runIPMIInClusterTimed(ctx, cfg, namespace, r)
-	return stdout, stderr, err
-}
-
-func runIPMIInClusterTimed(ctx context.Context, cfg *rest.Config, namespace string, r IPMIRequest) (stdout, stderr string, elapsed time.Duration, err error) {
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return "", "", 0, fmt.Errorf("building clientset: %w", err)
-	}
-	if err := CreateIPMIToolPod(ctx, clientset, namespace); err != nil {
-		return "", "", 0, err
-	}
-
-	start := time.Now()
-	stdout, stderr, err = execInPod(ctx, cfg, clientset, execOptions{
-		Namespace:     namespace,
-		PodName:       ipmitoolPodName,
-		ContainerName: "ipmitool",
-		Command:       buildIPMICommand(r),
-	})
-	return stdout, stderr, time.Since(start), err
 }
 
 func verifyDataVolumeExists(ctx context.Context, k8sClient client.Client, namespace, name string) {

--- a/test/virtbmc-agent/agent_test.go
+++ b/test/virtbmc-agent/agent_test.go
@@ -8,9 +8,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kubevirtv1 "kubevirt.io/api/core/v1"
 	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
 	"kubevirt.io/kubevirtbmc/pkg/util"
 	testutil "kubevirt.io/kubevirtbmc/test/util"
@@ -39,8 +39,8 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 		clientset, err := kubernetes.NewForConfig(config)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(CreateIPMIToolPod(ctx, clientset, ns)).To(Succeed())
-		Expect(CreateRedfishClientPod(ctx, clientset, ns)).To(Succeed())
+		Expect(testutil.CreateIPMIToolPod(ctx, clientset, ns)).To(Succeed())
+		Expect(testutil.CreateRedfishClientPod(ctx, clientset, ns)).To(Succeed())
 	})
 
 	ipmiReq := func(args ...string) IPMIRequest {
@@ -74,7 +74,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 	Context("IPMI enable/disable toggle", func() {
 		It("should start with IPMI disabled by default, verify failure, then enable", func() {
 			By("verifying IPMI commands fail when disabled by default")
-			_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
+			_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
 			Expect(err).To(HaveOccurred(), "IPMI command should fail when IPMI is disabled")
 
 			By("recording the current pod UID before enabling IPMI")
@@ -94,7 +94,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			By("creating a new Redfish session for the restarted pod")
 			Eventually(func() error {
-				authToken, err = CreateRedfishSession(ctx, config, ns, env.RedfishBaseURL, env.Username, env.Password)
+				authToken, err = testutil.CreateRedfishSession(ctx, config, ns, env.RedfishBaseURL, env.Username, env.Password)
 				return err
 			}, agentTestTimeout, agentTestInterval).Should(Succeed())
 			Expect(authToken).NotTo(BeEmpty())
@@ -104,7 +104,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 	Context("IPMI operations", func() {
 		Context("Authentication", func() {
 			It("should accept commands with correct username and password", func() {
-				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
+				out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Chassis Power is on"),
@@ -115,7 +115,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			It("should reject commands with wrong password", func() {
 				wrongReq := ipmiReq("power", "status")
 				wrongReq.Password = "wrongpass"
-				_, stderr, err := runIPMIInCluster(ctx, config, ns, wrongReq)
+				_, stderr, err := testutil.RunIPMIInCluster(ctx, config, ns, wrongReq)
 				Expect(err).To(HaveOccurred(), "IPMI command with wrong password should be rejected")
 				Expect(stderr).To(ContainSubstring("Unable to establish IPMI v2 / RMCP+ session"))
 			})
@@ -123,7 +123,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			It("should reject commands with wrong username", func() {
 				wrongReq := ipmiReq("power", "status")
 				wrongReq.Username = "baduser"
-				_, stderr, err := runIPMIInCluster(ctx, config, ns, wrongReq)
+				_, stderr, err := testutil.RunIPMIInCluster(ctx, config, ns, wrongReq)
 				Expect(err).To(HaveOccurred(), "IPMI command with wrong username should be rejected")
 				Expect(stderr).To(ContainSubstring("Unable to establish IPMI v2 / RMCP+ session"))
 			})
@@ -135,7 +135,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				func(iface string) {
 					req := ipmiReq("power", "status")
 					req.Interface = iface
-					out, _, err := runIPMIInCluster(ctx, config, ns, req)
+					out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, req)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(out).To(SatisfyAny(
 						ContainSubstring("Chassis Power is on"),
@@ -150,7 +150,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				func(iface string) {
 					req := ipmiReq("raw", "0x00", "0x08", "0x03", "0x08")
 					req.Interface = iface
-					_, _, err := runIPMIInCluster(ctx, config, ns, req)
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, req)
 					Expect(err).NotTo(HaveOccurred())
 				},
 				Entry("via lan", "lan"),
@@ -162,7 +162,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					req := ipmiReq("power", "status")
 					req.Interface = iface
 					req.RetryCount = 1
-					_, _, elapsed, err := runIPMIInClusterTimed(ctx, config, ns, req)
+					_, _, elapsed, err := testutil.RunIPMIInClusterTimed(ctx, config, ns, req)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(elapsed).To(BeNumerically("<", time.Second),
 						"%s power status with -R 1 should return within 1s, took %v", iface, elapsed)
@@ -174,7 +174,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 		Context("Power management", func() {
 			It("should report power status", func() {
-				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
+				out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "status"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Chassis Power is on"),
@@ -183,37 +183,37 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should accept power off and VM is actually off", func() {
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 			})
 
 			It("should accept power on and VM is actually running", func() {
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIRunning(ctx, k8sClient, ns)
 			})
 
 			It("should accept power cycle and VM is stopped then started again", func() {
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "cycle"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "cycle"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIPowerCycle(ctx, k8sClient, ns)
 			})
 
 			It("should accept power soft (graceful ACPI shutdown) and VM is actually off", func() {
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 			})
 
 			It("should accept power on and VM is actually running", func() {
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIRunning(ctx, k8sClient, ns)
 			})
 
 			It("should accept power reset (hard reset) and VM is stopped then started again", func() {
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "reset"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "reset"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIPowerCycle(ctx, k8sClient, ns)
 			})
@@ -223,22 +223,22 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				// before VM.Status.Ready flips. Reset in that window must
 				// Restart, not fall back to PowerOn (Always would swallow it).
 				waitForVMIRunning(ctx, k8sClient, ns)
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 
-				_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIPresentBeforeReady(ctx, k8sClient, ns)
 
-				_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "reset"))
+				_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "reset"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIPowerCycle(ctx, k8sClient, ns)
 			})
 
 			It("should return retryable error when power-on races with VMI cleanup", func() {
 				waitForVMIRunning(ctx, k8sClient, ns)
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
 				Expect(err).NotTo(HaveOccurred())
 
 				// Power on again before VMI cleanup completes: while the VMI
@@ -246,7 +246,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				// succeeds once the VMI is gone.
 				var sawNodeBusy bool
 				Eventually(func() error {
-					_, stderr, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+					_, stderr, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 					if err != nil {
 						sawNodeBusy = true
 						Expect(stderr).To(ContainSubstring("Node busy"),
@@ -263,16 +263,16 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should treat repeated power-on as idempotent during VM startup", func() {
 				waitForVMIRunning(ctx, k8sClient, ns)
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 
 				// The second power-on may arrive before the VMI is Ready;
 				// with RunStrategyAlways idempotency it must succeed, not
 				// return Node Busy.
-				_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred())
-				_, stderr, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, stderr, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred(),
 					"repeated power-on should succeed; stderr=%q", stderr)
 
@@ -281,7 +281,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should treat repeated power-on as idempotent for Manual runStrategy", func() {
 				waitForVMIRunning(ctx, k8sClient, ns)
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 
@@ -290,9 +290,9 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				setVMRunStrategy(ctx, k8sClient, ns, kubevirtv1.RunStrategyManual)
 				defer setVMRunStrategy(ctx, k8sClient, ns, kubevirtv1.RunStrategyAlways)
 
-				_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred())
-				_, stderr, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, stderr, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred(),
 					"repeated Manual power-on should succeed; stderr=%q", stderr)
 
@@ -301,12 +301,12 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should treat repeated power-off as idempotent", func() {
 				waitForVMIRunning(ctx, k8sClient, ns)
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
 				Expect(err).NotTo(HaveOccurred())
 
 				// Second power-off while VMI is being torn down should
 				// succeed idempotently.
-				_, stderr, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
+				_, stderr, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
 				Expect(err).NotTo(HaveOccurred(),
 					"repeated power-off should succeed; stderr=%q", stderr)
 
@@ -317,10 +317,10 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				// KubeVirt allows Stop to interrupt a pending/starting VMI, so this
 				// should succeed (unlike soft→on, which returns Node busy).
 				waitForVMIDeleted(ctx, k8sClient, ns)
-				_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+				_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 				Expect(err).NotTo(HaveOccurred())
 
-				_, stderr, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
+				_, stderr, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "soft"))
 				Expect(err).NotTo(HaveOccurred(),
 					"power soft after power on should succeed; stderr=%q", stderr)
 
@@ -334,7 +334,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should set boot device to PXE", func() {
-				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
+				out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Set Boot Device"),
@@ -349,7 +349,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should set boot device to disk", func() {
-				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk"))
+				out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Set Boot Device"),
@@ -364,7 +364,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should set boot device to cdrom", func() {
-				out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom"))
+				out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("Set Boot Device"),
@@ -380,7 +380,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			Context("oneshot boot order", func() {
 				It("should save boot override status on oneshot PXE", func() {
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
 					Expect(err).NotTo(HaveOccurred())
 					// PXE: interfaces first, then regular disks, then cdroms
 					verifyVMBootOrder(ctx, k8sClient, ns,
@@ -392,7 +392,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				})
 
 				It("should save persistent override marker on persistent PXE", func() {
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe", "options=persistent"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe", "options=persistent"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMBootOrder(ctx, k8sClient, ns,
 						map[int]uint{0: 2, 1: 3},
@@ -404,7 +404,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 				It("should cancel oneshot override with bootdev none", func() {
 					By("setting oneshot PXE first")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMBootOrder(ctx, k8sClient, ns,
 						map[int]uint{0: 2, 1: 3},
@@ -413,7 +413,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					verifyBMCBootOverride(ctx, k8sClient, ns, true)
 
 					By("cancelling with bootdev none")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "none"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "none"))
 					Expect(err).NotTo(HaveOccurred())
 
 					By("verifying original boot order restored and backup removed")
@@ -432,7 +432,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					addEmptyDiskWithBootOrder(ctx, k8sClient, ns, issue191RemovedDisk, 7)
 
 					By("setting oneshot PXE")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMNamedBootOrders(ctx, k8sClient, ns,
 						map[string]*uint{
@@ -459,12 +459,12 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					)
 
 					By("powering off the VM")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
 					Expect(err).NotTo(HaveOccurred())
 					waitForVMIDeleted(ctx, k8sClient, ns)
 
 					By("powering on the VM to consume the oneshot backup")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 					Expect(err).NotTo(HaveOccurred())
 					waitForVMIRunning(ctx, k8sClient, ns)
 
@@ -481,7 +481,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				})
 
 				It("should set EFI firmware template on running VM", func() {
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe", "options=efiboot"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe", "options=efiboot"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMBootOrder(ctx, k8sClient, ns,
 						map[int]uint{0: 2, 1: 3},
@@ -494,12 +494,12 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 				It("should set EFI firmware on stopped VM", func() {
 					By("stopping the VM")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
 					Expect(err).NotTo(HaveOccurred())
 					waitForVMIDeleted(ctx, k8sClient, ns)
 
 					By("setting EFI firmware")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk", "options=persistent,efiboot"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk", "options=persistent,efiboot"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMBootOrder(ctx, k8sClient, ns,
 						map[int]uint{0: 1, 1: 3},
@@ -510,14 +510,14 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					verifyBMCBootOverrideMode(ctx, k8sClient, ns, bmcv1.BootOverrideModePersistent)
 
 					By("restarting the VM")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 					Expect(err).NotTo(HaveOccurred())
 					waitForVMIRunning(ctx, k8sClient, ns)
 				})
 
 				It("should restore original boot order after multiple oneshot overrides before reboot", func() {
 					By("setting first oneshot to PXE")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMBootOrder(ctx, k8sClient, ns,
 						map[int]uint{0: 2, 1: 3},
@@ -526,7 +526,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					verifyBMCBootOverride(ctx, k8sClient, ns, true)
 
 					By("setting second oneshot to cdrom before reboot")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMBootOrder(ctx, k8sClient, ns,
 						map[int]uint{0: 2, 1: 1},
@@ -535,12 +535,12 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					verifyBMCBootOverride(ctx, k8sClient, ns, true)
 
 					By("powering off the VM")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "off"))
 					Expect(err).NotTo(HaveOccurred())
 					waitForVMIDeleted(ctx, k8sClient, ns)
 
 					By("powering on the VM to consume the oneshot")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("power", "on"))
 					Expect(err).NotTo(HaveOccurred())
 					waitForVMIRunning(ctx, k8sClient, ns)
 
@@ -552,7 +552,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					verifyBMCBootOverride(ctx, k8sClient, ns, false)
 
 					By("power cycling to get a clean VMI from the current template")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "power", "cycle"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "power", "cycle"))
 					Expect(err).NotTo(HaveOccurred())
 					waitForVMIPowerCycle(ctx, k8sClient, ns)
 
@@ -560,7 +560,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					waitForGuestAgent(ctx, k8sClient, ns)
 
 					By("setting oneshot HDD")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMBootOrder(ctx, k8sClient, ns,
 						map[int]uint{0: 1, 1: 3},
@@ -585,7 +585,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 				It("should consume oneshot after guest OS reboot on a VM with rebootPolicy=Terminate", Label("Slow"), func() {
 					By("power cycling to get a clean VMI from the current template")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "power", "cycle"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "power", "cycle"))
 					Expect(err).NotTo(HaveOccurred())
 					waitForVMIPowerCycle(ctx, k8sClient, ns)
 
@@ -593,7 +593,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					waitForGuestAgent(ctx, k8sClient, ns)
 
 					By("setting oneshot HDD")
-					_, _, err = runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk"))
+					_, _, err = testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk"))
 					Expect(err).NotTo(HaveOccurred())
 					verifyVMBootOrder(ctx, k8sClient, ns,
 						map[int]uint{0: 1, 1: 3},
@@ -620,11 +620,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			Context("bootparam get 5", func() {
 				It("should read back oneshot PXE boot flags", func() {
 					By("setting oneshot PXE")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe"))
 					Expect(err).NotTo(HaveOccurred())
 
 					By("reading back boot flags")
-					out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
+					out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(out).To(And(
 						ContainSubstring("Boot Flag Valid"),
@@ -635,11 +635,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 				It("should read back persistent HDD boot flags", func() {
 					By("setting persistent disk")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk", "options=persistent"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "disk", "options=persistent"))
 					Expect(err).NotTo(HaveOccurred())
 
 					By("reading back boot flags")
-					out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
+					out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(out).To(And(
 						ContainSubstring("Boot Flag Valid"),
@@ -650,11 +650,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 				It("should read back EFI oneshot CD boot flags", func() {
 					By("setting EFI oneshot CD")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom", "options=efiboot"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "cdrom", "options=efiboot"))
 					Expect(err).NotTo(HaveOccurred())
 
 					By("reading back boot flags")
-					out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
+					out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(out).To(And(
 						ContainSubstring("Boot Flag Valid"),
@@ -666,11 +666,11 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 				It("should read back persistent EFI PXE boot flags", func() {
 					By("setting persistent EFI PXE")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe", "options=persistent,efiboot"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe", "options=persistent,efiboot"))
 					Expect(err).NotTo(HaveOccurred())
 
 					By("reading back boot flags")
-					out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
+					out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(out).To(And(
 						ContainSubstring("Boot Flag Valid"),
@@ -682,7 +682,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 				It("should survive agent pod restart and persist boot flags", func() {
 					By("setting persistent PXE as a known state")
-					_, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe", "options=persistent"))
+					_, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootdev", "pxe", "options=persistent"))
 					Expect(err).NotTo(HaveOccurred())
 
 					By("recording the current agent pod UID")
@@ -698,7 +698,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					Eventually(testutil.PodRunningAndReadyWithNewUID(ctx, k8sClient, ns, podBefore.UID), agentTestTimeout, agentTestInterval).Should(BeTrue(), "new agent pod should become ready")
 
 					By("verifying bootparam get 5 returns correct state from CR status after restart")
-					out, _, err := runIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
+					out, _, err := testutil.RunIPMIInCluster(ctx, config, ns, ipmiReq("chassis", "bootparam", "get", "5"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(out).To(And(
 						ContainSubstring("Boot Flag Valid"),
@@ -708,13 +708,13 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 					By("re-creating Redfish session for restarted pod")
 					Eventually(func() error {
-						authToken, err = CreateRedfishSession(ctx, config, ns, env.RedfishBaseURL, env.Username, env.Password)
+						authToken, err = testutil.CreateRedfishSession(ctx, config, ns, env.RedfishBaseURL, env.Username, env.Password)
 						return err
 					}, agentTestTimeout, agentTestInterval).Should(Succeed())
 					Expect(authToken).NotTo(BeEmpty())
 
 					By("verifying Redfish GET also returns correct boot state after restart")
-					out2, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
+					out2, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(out2).To(And(
 						ContainSubstring(`"BootSourceOverrideTarget":"Pxe"`),
@@ -728,13 +728,13 @@ var _ = Describe("Agent e2e", Ordered, func() {
 	Context("Redfish operations", func() {
 		Context("Authentication", func() {
 			It("should allow access with basic auth", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishBasic("GET", "/Systems/1", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishBasic("GET", "/Systems/1", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring(`"@odata.id":"/redfish/v1/Systems/1"`))
 			})
 
 			It("should reject access with wrong password", func() {
-				out, err := runCurlRedfish(ctx, config, ns, RedfishRequest{
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, RedfishRequest{
 					BaseURL:  env.RedfishBaseURL,
 					Method:   "GET",
 					Path:     "/Systems/1",
@@ -749,7 +749,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should reject access with wrong username", func() {
-				out, err := runCurlRedfish(ctx, config, ns, RedfishRequest{
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, RedfishRequest{
 					BaseURL:  env.RedfishBaseURL,
 					Method:   "GET",
 					Path:     "/Systems/1",
@@ -766,7 +766,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 		Context("Service discovery", func() {
 			It("should return service root at /redfish/v1", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring(`"@odata.id":"/redfish/v1"`))
 				Expect(out).To(ContainSubstring("RedfishVersion"))
@@ -777,7 +777,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 		Context("Power management", func() {
 			It("should return system power state", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(SatisfyAny(
 					ContainSubstring("On"),
@@ -786,7 +786,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should advertise supported reset action values", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring(`"ResetType@Redfish.AllowableValues"`))
 				Expect(out).To(ContainSubstring(`"On"`))
@@ -797,37 +797,37 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should accept graceful shutdown action and VM is actually off", func() {
-				_, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"GracefulShutdown"}`))
+				_, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"GracefulShutdown"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 			})
 
 			It("should accept power on reset action and VM is actually running", func() {
-				_, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"On"}`))
+				_, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"On"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIRunning(ctx, k8sClient, ns)
 			})
 
 			It("should accept graceful restart action and VM is stopped then started again", func() {
-				_, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"GracefulRestart"}`))
+				_, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"GracefulRestart"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIPowerCycle(ctx, k8sClient, ns)
 			})
 
 			It("should accept force restart action and VM is stopped then started again", func() {
-				_, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"ForceRestart"}`))
+				_, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"ForceRestart"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIPowerCycle(ctx, k8sClient, ns)
 			})
 
 			It("should accept force off action and VM is actually off", func() {
-				_, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"ForceOff"}`))
+				_, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"ForceOff"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 			})
 
 			It("should accept power on reset action and VM is actually running", func() {
-				_, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"On"}`))
+				_, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"On"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIRunning(ctx, k8sClient, ns)
 			})
@@ -839,7 +839,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should return current boot configuration", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("Boot"))
 			})
@@ -847,7 +847,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			It("should set boot to PXE once", func() {
 				By("setting a one-time PXE boot override through Redfish")
 				body := `{"Boot":{"BootSourceOverrideTarget":"Pxe","BootSourceOverrideEnabled":"Once"}}`
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(out)).To(SatisfyAny(
 					ContainSubstring("200"),
@@ -861,12 +861,12 @@ var _ = Describe("Agent e2e", Ordered, func() {
 				verifyBMCBootOverride(ctx, k8sClient, ns, true)
 
 				By("powering off the VM")
-				_, err = runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"ForceOff"}`))
+				_, err = testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"ForceOff"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 
 				By("powering on the VM to consume the one-time override")
-				_, err = runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"On"}`))
+				_, err = testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"On"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIRunning(ctx, k8sClient, ns)
 
@@ -878,7 +878,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			It("should set boot to PXE continuous", func() {
 				verifyBMCBootOverride(ctx, k8sClient, ns, false)
 				body := `{"Boot":{"BootSourceOverrideTarget":"Pxe","BootSourceOverrideEnabled":"Continuous"}}`
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(out)).To(SatisfyAny(
 					ContainSubstring("200"),
@@ -894,7 +894,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should set boot to disk", func() {
 				body := `{"Boot":{"BootSourceOverrideTarget":"Hdd","BootSourceOverrideEnabled":"Once"}}`
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(out)).To(SatisfyAny(
 					ContainSubstring("200"),
@@ -909,7 +909,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should set boot to Cd", func() {
 				body := `{"Boot":{"BootSourceOverrideTarget":"Cd","BootSourceOverrideEnabled":"Once"}}`
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(out)).To(SatisfyAny(
 					ContainSubstring("200"),
@@ -924,7 +924,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should set boot mode to UEFI", func() {
 				body := `{"Boot":{"BootSourceOverrideMode":"UEFI"}}`
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(out)).To(SatisfyAny(
 					ContainSubstring("200"),
@@ -935,7 +935,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should set boot mode to Legacy", func() {
 				body := `{"Boot":{"BootSourceOverrideMode":"Legacy"}}`
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(out)).To(SatisfyAny(
 					ContainSubstring("200"),
@@ -947,7 +947,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 		Context("System and manager information", func() {
 			It("should return system details including boot override state", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "/Systems/1", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("ComputerSystem"))
 				Expect(out).To(ContainSubstring(`"BootSourceOverrideEnabled"`))
@@ -956,7 +956,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should return manager information", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Managers/BMC", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "/Managers/BMC", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("Manager"))
 			})
@@ -972,7 +972,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 		Context("Virtual Media Redfish API", func() {
 			It("should return virtual media resource CD1", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Managers/BMC/VirtualMedia/CD1", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "/Managers/BMC/VirtualMedia/CD1", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("VirtualMedia"))
 				Expect(out).To(ContainSubstring("CD1"))
@@ -983,14 +983,14 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should power off the VM", func() {
-				_, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"ForceOff"}`))
+				_, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Systems/1/Actions/ComputerSystem.Reset", `{"ResetType":"ForceOff"}`))
 				Expect(err).NotTo(HaveOccurred())
 				waitForVMIDeleted(ctx, k8sClient, ns)
 			})
 
 			It("should accept InsertMedia action", func() {
 				body := `{"Image":"https://releases.ubuntu.com/noble/ubuntu-24.04.3-live-server-amd64.iso","Inserted":true}`
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Managers/BMC/VirtualMedia/CD1/Actions/VirtualMedia.InsertMedia", body))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Managers/BMC/VirtualMedia/CD1/Actions/VirtualMedia.InsertMedia", body))
 				Expect(err).NotTo(HaveOccurred())
 				trimmed := strings.TrimSpace(out)
 				Expect(trimmed).To(SatisfyAny(
@@ -1007,7 +1007,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should return virtual media status after insert attempt", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("GET", "/Managers/BMC/VirtualMedia/CD1", ""))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("GET", "/Managers/BMC/VirtualMedia/CD1", ""))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("VirtualMedia"))
 				Expect(out).To(ContainSubstring("CD1"))
@@ -1015,7 +1015,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 
 			It("should set boot to Cd and verify CDROM becomes boot index 1", func() {
 				body := `{"Boot":{"BootSourceOverrideTarget":"Cd","BootSourceOverrideEnabled":"Once"}}`
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("PATCH", "/Systems/1", body))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(out)).To(SatisfyAny(
 					ContainSubstring("200"),
@@ -1029,7 +1029,7 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			})
 
 			It("should accept EjectMedia action", func() {
-				out, err := runCurlRedfish(ctx, config, ns, redfishSession("POST", "/Managers/BMC/VirtualMedia/CD1/Actions/VirtualMedia.EjectMedia", `{}`))
+				out, err := testutil.RunCurlRedfish(ctx, config, ns, redfishSession("POST", "/Managers/BMC/VirtualMedia/CD1/Actions/VirtualMedia.EjectMedia", `{}`))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(out)).To(SatisfyAny(
 					ContainSubstring("200"),

--- a/test/virtbmc-controller/controller_test.go
+++ b/test/virtbmc-controller/controller_test.go
@@ -25,6 +25,7 @@ const (
 	webhookServiceName      = "kubevirtbmc-webhook-service"
 	webhookServiceNamespace = "kubevirtbmc-system"
 	vmDeletionTimeout       = time.Second * 120
+	vmiFirstBootTimeout     = time.Second * 300
 )
 
 var (
@@ -110,7 +111,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 				}
 			}
 			By("waiting for the VirtualMachineInstance to reach Running phase")
-			Eventually(util.VMIRunning(ctx, k8sClient, util.E2EVMName, util.E2ENamespace), timeout, interval).Should(BeTrue(), "VMI should reach Running state")
+			Eventually(util.VMIRunning(ctx, k8sClient, util.E2EVMName, util.E2ENamespace), vmiFirstBootTimeout, interval).Should(BeTrue(), "VMI should reach Running state")
 		})
 
 		It("should allow creating a VirtualMachineBMC", func() {

--- a/test/virtbmc-controller/controller_test.go
+++ b/test/virtbmc-controller/controller_test.go
@@ -394,7 +394,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 		It("should default to ClusterIP when spec.service is not set", func() {
 			By("verifying the underlying Service defaults to type ClusterIP")
 			var svc corev1.Service
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc)).To(Succeed())
+			Expect(k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc)).To(Succeed())
 			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 
 			By("verifying the VirtualMachineBMC status reports only ClusterIP")
@@ -410,7 +410,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 		It("should recreate the Service as LoadBalancer and report a LoadBalancer ingress IP", func() {
 			By("recording the current ClusterIP Service before the type change")
 			var svcBefore corev1.Service
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svcBefore)).To(Succeed())
+			Expect(k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svcBefore)).To(Succeed())
 			Expect(svcBefore.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 
 			By("switching the VirtualMachineBMC Service type to LoadBalancer")
@@ -422,7 +422,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("verifying the old ClusterIP Service is deleted and/or recreated with a new UID")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return errors.IsNotFound(err)
 				}
 				return svc.UID != svcBefore.UID
@@ -431,7 +431,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("verifying the recreated Service has type LoadBalancer")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return false
 				}
 				return svc.Spec.Type == corev1.ServiceTypeLoadBalancer
@@ -440,7 +440,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("waiting for cloud-provider-kind to assign a LoadBalancer ingress IP")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return false
 				}
 				return len(svc.Status.LoadBalancer.Ingress) > 0 && svc.Status.LoadBalancer.Ingress[0].IP != ""
@@ -465,7 +465,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 		It("should recreate the Service as ClusterIP and clear the LoadBalancerIP when switched back", func() {
 			By("recording the current LoadBalancer Service before the type change")
 			var svcBefore corev1.Service
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svcBefore)).To(Succeed())
+			Expect(k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svcBefore)).To(Succeed())
 			Expect(svcBefore.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 
 			By("switching the VirtualMachineBMC Service type back to ClusterIP")
@@ -478,7 +478,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("verifying the LoadBalancer Service is deleted and/or recreated with a new UID")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return errors.IsNotFound(err)
 				}
 				return svc.UID != svcBefore.UID
@@ -487,7 +487,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("verifying the recreated Service has type ClusterIP")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return false
 				}
 				return svc.Spec.Type == corev1.ServiceTypeClusterIP
@@ -514,7 +514,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 		It("should patch the Service in-place, without requiring the Service to be manually deleted", func() {
 			By("recording the current Service UID before adding labels/annotations")
 			var svcBefore corev1.Service
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svcBefore)).To(Succeed())
+			Expect(k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svcBefore)).To(Succeed())
 			Expect(svcBefore.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 
 			By("setting spec.service.labels and spec.service.annotations on the VirtualMachineBMC")
@@ -530,7 +530,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("verifying the Service is patched in-place (same UID) with the new labels and annotations")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return false
 				}
 				return svc.UID == svcBefore.UID &&
@@ -540,7 +540,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 
 			By("verifying the base labels required for selection are preserved")
 			var svcAfterAdd corev1.Service
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svcAfterAdd)).To(Succeed())
+			Expect(k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svcAfterAdd)).To(Succeed())
 			Expect(svcAfterAdd.Labels).To(HaveKeyWithValue(bmcv1.VirtualMachineBMCNameLabel, util.E2EBMCName))
 
 			By("changing the label/annotation values again")
@@ -553,7 +553,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("verifying the Service reflects the updated values, still without a UID change")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return false
 				}
 				return svc.UID == svcBefore.UID &&
@@ -567,7 +567,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 		It("should refresh the reported ClusterIP once the owning controller recreates the Service", func() {
 			By("recording the current Service and BMC status before deletion")
 			var svcBefore corev1.Service
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svcBefore)).To(Succeed())
+			Expect(k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svcBefore)).To(Succeed())
 			Expect(svcBefore.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 
 			var bmcBefore bmcv1.VirtualMachineBMC
@@ -580,7 +580,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("verifying the owning controller automatically recreates the Service with a new UID")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return false
 				}
 				return svc.UID != svcBefore.UID && svc.Spec.ClusterIP != ""
@@ -589,7 +589,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("verifying the VirtualMachineBMC status tracks the recreated Service's ClusterIP, not the stale one")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return false
 				}
 				var bmc bmcv1.VirtualMachineBMC


### PR DESCRIPTION
fix #255 

https://github.com/halfcrazy/kubevirtbmc/actions/runs/30919192464/job/92025044214


FYI: UEFI is much slower because of the bug https://github.com/kubevirtbmc/kubevirtbmc/issues/222. Legacy tries the next NIC faster, while UEFI wastes more time.