### PR TITLE
Feat: Replace pod with deployment

### DIFF
--- a/api/bmc/v1beta1/virtualmachinebmc_types.go
+++ b/api/bmc/v1beta1/virtualmachinebmc_types.go
@@ -26,10 +26,9 @@ const (
 	ConditionReady                   = "Ready"
 	ConditionVirtualMachineAvailable = "VirtualMachineAvailable"
 	ConditionSecretAvailable         = "SecretAvailable"
+	VirtualMachineBMCNameLabel       = "kubevirt.io/virtualmachinebmc-name"
+	VMNameLabel                      = "kubevirt.io/vm-name"
 )
-
-// VirtualMachineBMCNameLabel lives here (not in the controller package) so the virtbmc agent binary, which only builds from api/ and pkg/, can read it too.
-const VirtualMachineBMCNameLabel = "kubevirt.io/virtualmachinebmc-name"
 
 // VirtualMachineBMCSpec defines the desired state of VirtualMachineBMC.
 type VirtualMachineBMCSpec struct {

--- a/api/bmc/v1beta1/virtualmachinebmc_types.go
+++ b/api/bmc/v1beta1/virtualmachinebmc_types.go
@@ -28,6 +28,9 @@ const (
 	ConditionSecretAvailable         = "SecretAvailable"
 )
 
+// VirtualMachineBMCNameLabel lives here (not in the controller package) so the virtbmc agent binary, which only builds from api/ and pkg/, can read it too.
+const VirtualMachineBMCNameLabel = "kubevirt.io/virtualmachinebmc-name"
+
 // VirtualMachineBMCSpec defines the desired state of VirtualMachineBMC.
 type VirtualMachineBMCSpec struct {
 	// Reference to the VM to manage.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: anish60/virtbmc-controller
-  newTag: deployv1
+  newName: kubevirtbmc/virtbmc-controller
+  newTag: dev

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: kubevirtbmc/virtbmc-controller
-  newTag: dev
+  newName: anish60/virtbmc-controller
+  newTag: deployv1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,6 +63,8 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          - --agent-image-name=anish60/virtbmc
+          - --agent-image-tag=deploy
         image: controller:latest
         name: manager
         ports: []

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,8 +63,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --agent-image-name=anish60/virtbmc
-          - --agent-image-tag=deploy
         image: controller:latest
         name: manager
         ports: []

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - bmc.kubevirt.io
   resources:
   - virtualmachinebmcs

--- a/internal/controller/service/controller.go
+++ b/internal/controller/service/controller.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
-	ctlvirtualmachinebmc "kubevirt.io/kubevirtbmc/internal/controller/virtualmachinebmc"
 )
 
 // ServiceReconciler reconciles a Service object
@@ -60,7 +59,7 @@ func (s *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if svc.Labels == nil {
 		return ctrl.Result{}, nil
 	}
-	virtualMachineBMCName, ok := svc.Labels[ctlvirtualmachinebmc.VirtualMachineBMCNameLabel]
+	virtualMachineBMCName, ok := svc.Labels[bmcv1.VirtualMachineBMCNameLabel]
 	if !ok {
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/service/controller_test.go
+++ b/internal/controller/service/controller_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Service Controller", func() {
 			svc := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						ctlvirtualmachinebmc.VirtualMachineBMCNameLabel: testVirtualMachineBMCName,
+						bmcv1.VirtualMachineBMCNameLabel: testVirtualMachineBMCName,
 					},
 					Name:      testVMName + "-virtbmc",
 					Namespace: testVirtualMachineBMCNamespace,
@@ -204,7 +204,7 @@ var _ = Describe("Service Controller", func() {
 			svc := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						ctlvirtualmachinebmc.VirtualMachineBMCNameLabel: "test-vmbmc-no-ip",
+						bmcv1.VirtualMachineBMCNameLabel: "test-vmbmc-no-ip",
 					},
 					Name:      "test-vm-no-ip-virtbmc",
 					Namespace: testVirtualMachineBMCNamespace,

--- a/internal/controller/virtualmachinebmc/bmc_controller.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -153,129 +153,6 @@ func (r *VirtualMachineBMCReconciler) agentResourceRequests() corev1.ResourceLis
 	}
 }
 
-func (r *VirtualMachineBMCReconciler) constructPodFromVirtualMachineBMC(virtualMachineBMC *bmcv1.VirtualMachineBMC) *corev1.Pod {
-	name := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
-	serviceAccountName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
-	var secretName string
-	if virtualMachineBMC.Spec.AuthSecretRef != nil {
-		secretName = virtualMachineBMC.Spec.AuthSecretRef.Name
-	}
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
-				VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
-			},
-			Annotations: map[string]string{
-				EnableIPMIAnnotation: strconv.FormatBool(specIPMIEnabled(&virtualMachineBMC.Spec)),
-			},
-			Name:      name,
-			Namespace: virtualMachineBMC.Namespace,
-		},
-		Spec: corev1.PodSpec{
-			ServiceAccountName: serviceAccountName,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:  virtBMCContainerName,
-					Image: fmt.Sprintf("%s:%s", r.AgentImageName, r.AgentImageTag),
-					Args: func() []string {
-						args := []string{
-							"--address",
-							"0.0.0.0",
-							"--redfish-port",
-							strconv.Itoa(redfishPort),
-						}
-						if specIPMIEnabled(&virtualMachineBMC.Spec) {
-							args = append(args, "--enable-ipmi", "--ipmi-port", strconv.Itoa(ipmiPort))
-						}
-						args = append(args, virtualMachineBMC.Namespace, virtualMachineBMC.Spec.VirtualMachineRef.Name)
-						return args
-					}(),
-					Ports: func() []corev1.ContainerPort {
-						ports := []corev1.ContainerPort{
-							{
-								Name:          redfishPortName,
-								ContainerPort: redfishPort,
-								Protocol:      corev1.ProtocolTCP,
-							},
-						}
-						if specIPMIEnabled(&virtualMachineBMC.Spec) {
-							ports = append(ports, corev1.ContainerPort{
-								Name:          ipmiPortName,
-								ContainerPort: ipmiPort,
-								Protocol:      corev1.ProtocolUDP,
-							})
-						}
-						return ports
-					}(),
-					Env: []corev1.EnvVar{
-						{
-							Name: "BMC_USERNAME",
-							ValueFrom: &corev1.EnvVarSource{
-								SecretKeyRef: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: secretName,
-									},
-									Key: bmcUserKey,
-								},
-							},
-						},
-						{
-							Name: "BMC_PASSWORD",
-							ValueFrom: &corev1.EnvVarSource{
-								SecretKeyRef: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: secretName,
-									},
-									Key: bmcPasswordKey,
-								},
-							},
-						},
-						{
-							Name: "POD_NAME",
-							ValueFrom: &corev1.EnvVarSource{
-								FieldRef: &corev1.ObjectFieldSelector{
-									FieldPath: "metadata.name",
-								},
-							},
-						},
-					},
-					ReadinessProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path: "/redfish/v1",
-								Port: intstr.FromString(redfishPortName),
-							},
-						},
-						InitialDelaySeconds: 2,
-						PeriodSeconds:       10,
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: r.agentResourceRequests(),
-					},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-						ReadOnlyRootFilesystem:   ptr.To(true),
-						RunAsNonRoot:             ptr.To(true),
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return pod
-}
-
 func (r *VirtualMachineBMCReconciler) constructServiceFromVirtualMachineBMC(virtualMachineBMC *bmcv1.VirtualMachineBMC) *corev1.Service {
 	name := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
 
@@ -315,30 +192,6 @@ func (r *VirtualMachineBMCReconciler) constructServiceFromVirtualMachineBMC(virt
 	}
 
 	return svc
-}
-
-func (r *VirtualMachineBMCReconciler) deleteVirtBMCPod(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
-	log := log.FromContext(ctx)
-	podName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: virtualMachineBMC.Namespace,
-		},
-	}
-
-	if err := r.Delete(ctx, pod); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.V(1).Info("virtBMC Pod already absent", "pod", podName)
-			return nil
-		}
-
-		log.Error(err, "unable to delete virtBMC Pod", "pod", podName)
-		return err
-	}
-
-	return nil
 }
 
 // patchStatusCondition records the given condition on the VirtualMachineBMC
@@ -436,26 +289,16 @@ func (r *VirtualMachineBMCReconciler) validateSecretExists(ctx context.Context, 
 	return true, nil
 }
 
-func (r *VirtualMachineBMCReconciler) getVirtBMCPod(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (*corev1.Pod, error) {
-	podName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
-
-	pod := &corev1.Pod{}
-	if err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: virtualMachineBMC.Namespace}, pod); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return pod, nil
-}
-
 func specIPMIEnabled(spec *bmcv1.VirtualMachineBMCSpec) bool {
 	return spec.IPMI != nil && spec.IPMI.Enabled != nil && *spec.IPMI.Enabled
 }
 
-func podIPMIEnabled(pod *corev1.Pod) bool {
-	val, ok := pod.Annotations[EnableIPMIAnnotation]
+// deploymentIPMIEnabled reports the IPMI state stamped on the Deployment's pod
+// template by constructDeploymentFromVirtualMachineBMC, so it can be compared
+// against the desired spec without depending on the underlying Pod's name
+// (which the Deployment's ReplicaSet generates dynamically).
+func deploymentIPMIEnabled(deployment *appsv1.Deployment) bool {
+	val, ok := deployment.Spec.Template.Annotations[EnableIPMIAnnotation]
 	if !ok {
 		return false
 	}
@@ -500,33 +343,34 @@ func (r *VirtualMachineBMCReconciler) patchVirtBMCServicePorts(
 }
 
 // reconcileIPMIChange detects a mismatch between the spec's enableIPMI flag and
-// the stamped annotation on the existing pod. When a mismatch is found it
-// deletes the stale pod (ports are immutable) and patches the Service in-place
-// (preserving ClusterIP), then requeues so the main loop recreates the pod.
+// the IPMI annotation stamped on the Deployment's pod template. When a mismatch
+// is found it deletes the stale Deployment (ports are immutable) and patches
+// the Service in-place (preserving ClusterIP), then requeues so the main loop
+// recreates the Deployment.
 func (r *VirtualMachineBMCReconciler) reconcileIPMIChange(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (requeue bool, err error) {
 	log := log.FromContext(ctx)
 
-	pod, err := r.getVirtBMCPod(ctx, virtualMachineBMC)
+	deployment, err := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
 	if err != nil {
 		return false, err
 	}
 
-	if pod == nil {
+	if deployment == nil {
 		return false, nil
 	}
 
-	currentHasIPMI := podIPMIEnabled(pod)
+	currentHasIPMI := deploymentIPMIEnabled(deployment)
 	desiredHasIPMI := specIPMIEnabled(&virtualMachineBMC.Spec)
 
 	if currentHasIPMI == desiredHasIPMI {
 		return false, nil
 	}
 
-	log.Info("enableIPMI changed, replacing pod and patching service",
+	log.Info("enableIPMI changed, replacing deployment and patching service",
 		"currentHasIPMI", currentHasIPMI,
 		"desiredHasIPMI", desiredHasIPMI)
 
-	if err := r.deleteVirtBMCPod(ctx, virtualMachineBMC); err != nil {
+	if err := r.deleteVirtBMCDeployment(ctx, virtualMachineBMC); err != nil {
 		return false, err
 	}
 
@@ -543,6 +387,7 @@ func (r *VirtualMachineBMCReconciler) reconcileIPMIChange(ctx context.Context, v
 //+kubebuilder:rbac:groups=bmc.kubevirt.io,resources=virtualmachinebmcs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=bmc.kubevirt.io,resources=virtualmachinebmcs/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=pods;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
@@ -579,8 +424,8 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if !vmExists || !secretExists {
-		if err := r.deleteVirtBMCPod(ctx, &virtualMachineBMC); err != nil {
-			log.Error(err, "unable to delete virtBMC Pod")
+		if err := r.deleteVirtBMCDeployment(ctx, &virtualMachineBMC); err != nil {
+			log.Error(err, "unable to delete virtBMC Deployment")
 			return ctrl.Result{}, err
 		}
 	}
@@ -605,19 +450,9 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Prepare the virtBMC Pod
-	pod := r.constructPodFromVirtualMachineBMC(&virtualMachineBMC)
-	if err := ctrl.SetControllerReference(&virtualMachineBMC, pod, r.Scheme); err != nil {
+	if err := r.ensureVirtBMCDeployment(ctx, &virtualMachineBMC); err != nil {
 		return ctrl.Result{}, err
 	}
-
-	// Create the virtBMC Pod on the cluster
-	if err := r.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
-		log.Error(err, "unable to create Pod for VirtualMachineBMC", "pod", pod)
-		return ctrl.Result{}, err
-	}
-
-	log.V(1).Info("created Pod for VirtualMachineBMC", "pod", pod)
 
 	// Prepare the virtBMC Service
 	svc := r.constructServiceFromVirtualMachineBMC(&virtualMachineBMC)
@@ -714,10 +549,10 @@ func (r *VirtualMachineBMCReconciler) findVirtualMachineBMCsForSecretAndVM(ctx c
 		case *corev1.Secret:
 			if vmBMC.Spec.AuthSecretRef != nil && vmBMC.Spec.AuthSecretRef.Name == o.GetName() {
 				vmBMCCopy := vmBMC.DeepCopy()
-				if err := r.deleteVirtBMCPod(ctx, vmBMCCopy); err != nil {
-					log.Error(err, "unable to delete virtBMC Pod during Secret change", "vmBMC", vmBMC.Name)
+				if err := r.rolloutRestartVirtBMCDeployment(ctx, vmBMCCopy); err != nil {
+					log.Error(err, "unable to restart virtBMC Deployment during Secret change", "vmBMC", vmBMC.Name)
 				}
-				log.Info("Deleted virtBMC Pod after Secret change")
+				log.Info("Restarted virtBMC deployment after Secret change")
 
 				match = true
 			}

--- a/internal/controller/virtualmachinebmc/bmc_controller.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller.go
@@ -293,10 +293,6 @@ func specIPMIEnabled(spec *bmcv1.VirtualMachineBMCSpec) bool {
 	return spec.IPMI != nil && spec.IPMI.Enabled != nil && *spec.IPMI.Enabled
 }
 
-// deploymentIPMIEnabled reports the IPMI state stamped on the Deployment's pod
-// template by constructDeploymentFromVirtualMachineBMC, so it can be compared
-// against the desired spec without depending on the underlying Pod's name
-// (which the Deployment's ReplicaSet generates dynamically).
 func deploymentIPMIEnabled(deployment *appsv1.Deployment) bool {
 	val, ok := deployment.Spec.Template.Annotations[EnableIPMIAnnotation]
 	if !ok {
@@ -450,8 +446,7 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Delete the pre-Deployment fixed-name agent pod so the new Deployment
-	// is the sole agent. Runs before Apply to avoid dual-serving on the Service.
+	// Migration cleanup: remove any pre-Deployment fixed-name agent Pod before applying the Deployment.
 	deployName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
 	legacyPod := &corev1.Pod{}
 	err = r.Get(ctx, types.NamespacedName{Name: deployName, Namespace: virtualMachineBMC.Namespace}, legacyPod)

--- a/internal/controller/virtualmachinebmc/bmc_controller.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller.go
@@ -159,15 +159,15 @@ func (r *VirtualMachineBMCReconciler) constructServiceFromVirtualMachineBMC(virt
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
-				VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
+				bmcv1.VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
+				bmcv1.VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
 			},
 			Name:      name,
 			Namespace: virtualMachineBMC.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
+				bmcv1.VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
 			},
 			Ports: func() []corev1.ServicePort {
 				ports := []corev1.ServicePort{

--- a/internal/controller/virtualmachinebmc/bmc_controller.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller.go
@@ -450,6 +450,19 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
+	// Delete the pre-Deployment fixed-name agent pod so the new Deployment
+	// is the sole agent. Runs before Apply to avoid dual-serving on the Service.
+	deployName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+	legacyPod := &corev1.Pod{}
+	err = r.Get(ctx, types.NamespacedName{Name: deployName, Namespace: virtualMachineBMC.Namespace}, legacyPod)
+	if err == nil && metav1.IsControlledBy(legacyPod, &virtualMachineBMC) {
+		if err := r.Delete(ctx, legacyPod); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
 	if err := r.ensureVirtBMCDeployment(ctx, &virtualMachineBMC); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -473,10 +486,10 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *VirtualMachineBMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, ownerKey, func(rawObj client.Object) []string {
-		// grab the pod object, extract the owner...
-		pod := rawObj.(*corev1.Pod)
-		owner := metav1.GetControllerOf(pod)
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &appsv1.Deployment{}, ownerKey, func(rawObj client.Object) []string {
+		// grab the deployment object, extract the owner...
+		deployment := rawObj.(*appsv1.Deployment)
+		owner := metav1.GetControllerOf(deployment)
 		if owner == nil {
 			return nil
 		}
@@ -511,7 +524,7 @@ func (r *VirtualMachineBMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bmcv1.VirtualMachineBMC{}).
-		Owns(&corev1.Pod{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.RoleBinding{}).

--- a/internal/controller/virtualmachinebmc/bmc_controller.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller.go
@@ -338,43 +338,30 @@ func (r *VirtualMachineBMCReconciler) patchVirtBMCServicePorts(
 	return nil
 }
 
-// reconcileIPMIChange detects a mismatch between the spec's enableIPMI flag and
-// the IPMI annotation stamped on the Deployment's pod template. When a mismatch
-// is found it deletes the stale Deployment (ports are immutable) and patches
-// the Service in-place (preserving ClusterIP), then requeues so the main loop
-// recreates the Deployment.
-func (r *VirtualMachineBMCReconciler) reconcileIPMIChange(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (requeue bool, err error) {
+func (r *VirtualMachineBMCReconciler) reconcileIPMIChange(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
 	log := log.FromContext(ctx)
 
 	deployment, err := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if deployment == nil {
-		return false, nil
+		return nil
 	}
 
 	currentHasIPMI := deploymentIPMIEnabled(deployment)
 	desiredHasIPMI := specIPMIEnabled(&virtualMachineBMC.Spec)
 
 	if currentHasIPMI == desiredHasIPMI {
-		return false, nil
+		return nil
 	}
 
-	log.Info("enableIPMI changed, replacing deployment and patching service",
+	log.Info("enableIPMI changed, patching Service ports",
 		"currentHasIPMI", currentHasIPMI,
 		"desiredHasIPMI", desiredHasIPMI)
 
-	if err := r.deleteVirtBMCDeployment(ctx, virtualMachineBMC); err != nil {
-		return false, err
-	}
-
-	if err := r.patchVirtBMCServicePorts(ctx, virtualMachineBMC); err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return r.patchVirtBMCServicePorts(ctx, virtualMachineBMC)
 }
 
 //+kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=get;list;watch;update;patch
@@ -434,12 +421,8 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	deleted, err := r.reconcileIPMIChange(ctx, &virtualMachineBMC)
-	if err != nil {
+	if err := r.reconcileIPMIChange(ctx, &virtualMachineBMC); err != nil {
 		return ctrl.Result{}, err
-	}
-	if deleted {
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	if err := r.ensureRBACResources(ctx, &virtualMachineBMC); err != nil {
@@ -546,12 +529,6 @@ func (r *VirtualMachineBMCReconciler) findVirtualMachineBMCsForSecretAndVM(ctx c
 
 		case *corev1.Secret:
 			if vmBMC.Spec.AuthSecretRef != nil && vmBMC.Spec.AuthSecretRef.Name == o.GetName() {
-				vmBMCCopy := vmBMC.DeepCopy()
-				if err := r.rolloutRestartVirtBMCDeployment(ctx, vmBMCCopy); err != nil {
-					log.Error(err, "unable to restart virtBMC Deployment during Secret change", "vmBMC", vmBMC.Name)
-				}
-				log.Info("Restarted virtBMC deployment after Secret change")
-
 				match = true
 			}
 		}

--- a/internal/controller/virtualmachinebmc/bmc_controller.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller.go
@@ -446,15 +446,7 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Migration cleanup: remove any pre-Deployment fixed-name agent Pod before applying the Deployment.
-	deployName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
-	legacyPod := &corev1.Pod{}
-	err = r.Get(ctx, types.NamespacedName{Name: deployName, Namespace: virtualMachineBMC.Namespace}, legacyPod)
-	if err == nil && metav1.IsControlledBy(legacyPod, &virtualMachineBMC) {
-		if err := r.Delete(ctx, legacyPod); err != nil && !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, err
-		}
-	} else if err != nil && !apierrors.IsNotFound(err) {
+	if err := r.deleteLegacyVirtBMCPod(ctx, &virtualMachineBMC); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -462,13 +454,11 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Prepare the virtBMC Service
 	svc := r.constructServiceFromVirtualMachineBMC(&virtualMachineBMC)
 	if err := ctrl.SetControllerReference(&virtualMachineBMC, svc, r.Scheme); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// Create the virtBMC Service on the cluster
 	if err := r.Create(ctx, svc); err != nil && !apierrors.IsAlreadyExists(err) {
 		log.Error(err, "unable to create Service for VirtualMachineBMC", "svc", svc)
 		return ctrl.Result{}, err

--- a/internal/controller/virtualmachinebmc/bmc_controller.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller.go
@@ -19,7 +19,6 @@ package virtualmachinebmc
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -293,18 +292,6 @@ func specIPMIEnabled(spec *bmcv1.VirtualMachineBMCSpec) bool {
 	return spec.IPMI != nil && spec.IPMI.Enabled != nil && *spec.IPMI.Enabled
 }
 
-func deploymentIPMIEnabled(deployment *appsv1.Deployment) bool {
-	val, ok := deployment.Spec.Template.Annotations[EnableIPMIAnnotation]
-	if !ok {
-		return false
-	}
-	enabled, err := strconv.ParseBool(val)
-	if err != nil {
-		return false
-	}
-	return enabled
-}
-
 func (r *VirtualMachineBMCReconciler) patchVirtBMCServicePorts(
 	ctx context.Context,
 	virtualMachineBMC *bmcv1.VirtualMachineBMC,
@@ -336,32 +323,6 @@ func (r *VirtualMachineBMCReconciler) patchVirtBMCServicePorts(
 	log.V(1).Info("patched Service ports in-place", "svc", svcName,
 		"ports", existing.Spec.Ports)
 	return nil
-}
-
-func (r *VirtualMachineBMCReconciler) reconcileIPMIChange(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
-	log := log.FromContext(ctx)
-
-	deployment, err := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
-	if err != nil {
-		return err
-	}
-
-	if deployment == nil {
-		return nil
-	}
-
-	currentHasIPMI := deploymentIPMIEnabled(deployment)
-	desiredHasIPMI := specIPMIEnabled(&virtualMachineBMC.Spec)
-
-	if currentHasIPMI == desiredHasIPMI {
-		return nil
-	}
-
-	log.Info("enableIPMI changed, patching Service ports",
-		"currentHasIPMI", currentHasIPMI,
-		"desiredHasIPMI", desiredHasIPMI)
-
-	return r.patchVirtBMCServicePorts(ctx, virtualMachineBMC)
 }
 
 //+kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=get;list;watch;update;patch
@@ -421,7 +382,7 @@ func (r *VirtualMachineBMCReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.reconcileIPMIChange(ctx, &virtualMachineBMC); err != nil {
+	if err := r.patchVirtBMCServicePorts(ctx, &virtualMachineBMC); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/virtualmachinebmc/bmc_controller_test.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller_test.go
@@ -145,10 +145,10 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(createdDeployment.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
-			Expect(createdDeployment.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
-			Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
-			Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
+			Expect(createdDeployment.Labels).To(HaveKeyWithValue(bmcv1.VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
+			Expect(createdDeployment.Labels).To(HaveKeyWithValue(bmcv1.VMNameLabel, testVMName))
+			Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue(bmcv1.VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
+			Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue(bmcv1.VMNameLabel, testVMName))
 			Expect(createdDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(serviceAccountName))
 			Expect(createdDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(createdDeployment.Spec.Template.Spec.Containers[0].Name).To(Equal(virtBMCContainerName))
@@ -192,9 +192,9 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(createdSvc.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
-			Expect(createdSvc.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
-			Expect(createdSvc.Spec.Selector).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
+			Expect(createdSvc.Labels).To(HaveKeyWithValue(bmcv1.VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
+			Expect(createdSvc.Labels).To(HaveKeyWithValue(bmcv1.VMNameLabel, testVMName))
+			Expect(createdSvc.Spec.Selector).To(HaveKeyWithValue(bmcv1.VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
 			Expect(createdSvc.Spec.Ports).To(HaveLen(1))
 		})
 
@@ -654,8 +654,8 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return restartedAt != "" && restartedAt != originalRestartedAt
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, bmcName))
-			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VMNameLabel, vmName))
+			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(bmcv1.VirtualMachineBMCNameLabel, bmcName))
+			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(bmcv1.VMNameLabel, vmName))
 			Expect(updatedDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(vmName + "-virtbmc"))
 		})
 

--- a/internal/controller/virtualmachinebmc/bmc_controller_test.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,7 +49,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 		serviceAccountName := fmt.Sprintf("%s-virtbmc", testVMName)
 		roleBindingName := fmt.Sprintf("%s-virtbmc-rolebinding", testVMName)
 
-		It("Should create RBAC resources, Pod and Service ", func() {
+		It("Should create RBAC resources, Deployment and Service ", func() {
 			ctx := context.Background()
 
 			By("Creating the referenced VirtualMachine first")
@@ -132,41 +133,43 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(createdRB.Subjects).To(HaveLen(1))
 			Expect(createdRB.Subjects[0].Name).To(Equal(serviceAccountName))
 
-			By("Checking that the Pod is created with correct name")
-			podLookupKey := types.NamespacedName{
+			By("Checking that the Deployment is created with correct name")
+			deploymentLookupKey := types.NamespacedName{
 				Name:      testVMName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
-			createdPod := &corev1.Pod{}
+			createdDeployment := &appsv1.Deployment{}
 
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, createdPod)
+				err := k8sClient.Get(ctx, deploymentLookupKey, createdDeployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(createdPod.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
-			Expect(createdPod.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
-			Expect(createdPod.Spec.ServiceAccountName).To(Equal(serviceAccountName))
-			Expect(createdPod.Spec.Containers).To(HaveLen(1))
-			Expect(createdPod.Spec.Containers[0].Name).To(Equal(virtBMCContainerName))
-			Expect(createdPod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal(DefaultAgentCPURequest))
-			Expect(createdPod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(DefaultAgentMemoryRequest))
+			Expect(createdDeployment.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
+			Expect(createdDeployment.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
+			Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, testVirtualMachineBMCName))
+			Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VMNameLabel, testVMName))
+			Expect(createdDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(serviceAccountName))
+			Expect(createdDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(createdDeployment.Spec.Template.Spec.Containers[0].Name).To(Equal(virtBMCContainerName))
+			Expect(createdDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal(DefaultAgentCPURequest))
+			Expect(createdDeployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(DefaultAgentMemoryRequest))
 			hasPodNameEnv := false
-			for _, env := range createdPod.Spec.Containers[0].Env {
+			for _, env := range createdDeployment.Spec.Template.Spec.Containers[0].Env {
 				if env.Name == "POD_NAME" && env.ValueFrom != nil && env.ValueFrom.FieldRef != nil && env.ValueFrom.FieldRef.FieldPath == "metadata.name" {
 					hasPodNameEnv = true
 				}
 			}
 			Expect(hasPodNameEnv).To(BeTrue())
 
-			By("Checking that the Pod and container have a restricted-compliant securityContext")
-			Expect(createdPod.Spec.SecurityContext).NotTo(BeNil())
-			Expect(createdPod.Spec.SecurityContext.RunAsNonRoot).NotTo(BeNil())
-			Expect(*createdPod.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
-			Expect(createdPod.Spec.SecurityContext.SeccompProfile).NotTo(BeNil())
-			Expect(createdPod.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+			By("Checking that the Pod template and container have a restricted-compliant securityContext")
+			Expect(createdDeployment.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+			Expect(createdDeployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot).NotTo(BeNil())
+			Expect(*createdDeployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(createdDeployment.Spec.Template.Spec.SecurityContext.SeccompProfile).NotTo(BeNil())
+			Expect(createdDeployment.Spec.Template.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 
-			container := createdPod.Spec.Containers[0]
+			container := createdDeployment.Spec.Template.Spec.Containers[0]
 			Expect(container.SecurityContext).NotTo(BeNil())
 			Expect(container.SecurityContext.AllowPrivilegeEscalation).NotTo(BeNil())
 			Expect(*container.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
@@ -398,14 +401,14 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 
-			By("Waiting for Pod to be created")
-			podLookupKey := types.NamespacedName{
+			By("Waiting for Deployment to be created")
+			deploymentLookupKey := types.NamespacedName{
 				Name:      vmName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
 			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
+				deployment := &appsv1.Deployment{}
+				err := k8sClient.Get(ctx, deploymentLookupKey, deployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
@@ -446,7 +449,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(foundCondition).To(BeTrue())
 		})
 
-		It("Should update condition and delete Pod when Secret is deleted", func() {
+		It("Should update condition and delete Deployment when Secret is deleted", func() {
 			ctx := context.Background()
 
 			vmName := "testvm-secret-delete"
@@ -519,14 +522,14 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 
-			By("Waiting for Pod to be created")
-			podLookupKey := types.NamespacedName{
+			By("Waiting for Deployment to be created")
+			deploymentLookupKey := types.NamespacedName{
 				Name:      vmName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
 			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
+				deployment := &appsv1.Deployment{}
+				err := k8sClient.Get(ctx, deploymentLookupKey, deployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
@@ -551,15 +554,15 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 
-			By("Verifying that the Pod is deleted")
+			By("Verifying that the Deployment is deleted")
 			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
+				deployment := &appsv1.Deployment{}
+				err := k8sClient.Get(ctx, deploymentLookupKey, deployment)
 				return errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 
-		It("Should delete and recreate Pod when Secret is changed", func() {
+		It("Should trigger a Deployment rollout when Secret is changed", func() {
 			ctx := context.Background()
 
 			vmName := "testvm-secret-change"
@@ -613,18 +616,21 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, virtualMachineBMC)).To(Succeed())
 
-			By("Waiting for Pod to be created")
-			podLookupKey := types.NamespacedName{
+			By("Waiting for Deployment to be created")
+			deploymentLookupKey := types.NamespacedName{
 				Name:      vmName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
-			var originalPod corev1.Pod
+			var originalDeployment appsv1.Deployment
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, &originalPod)
+				err := k8sClient.Get(ctx, deploymentLookupKey, &originalDeployment)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			originalPodUID := originalPod.UID
+			originalRestartedAt := ""
+			if originalDeployment.Spec.Template.Annotations != nil {
+				originalRestartedAt = originalDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+			}
 
 			By("Updating the Secret with new credentials")
 			updatedSecret := &corev1.Secret{}
@@ -635,34 +641,22 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, updatedSecret)).Should(Succeed())
 
-			By("Verifying that the old Pod is deleted")
+			By("Verifying the Deployment template gets a restart annotation")
+			var updatedDeployment appsv1.Deployment
 			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
-				if err != nil {
-					return errors.IsNotFound(err)
-				}
-				// Check if it's a different pod (new UID)
-				return pod.UID != originalPodUID
-			}, timeout, interval).Should(BeTrue())
-
-			By("Verifying that a new Pod is created by the controller")
-			Eventually(func() bool {
-				pod := &corev1.Pod{}
-				err := k8sClient.Get(ctx, podLookupKey, pod)
-				if err != nil {
+				if err := k8sClient.Get(ctx, deploymentLookupKey, &updatedDeployment); err != nil {
 					return false
 				}
-				// Verify it's a new pod with different UID
-				return pod.UID != originalPodUID
+				if updatedDeployment.Spec.Template.Annotations == nil {
+					return false
+				}
+				restartedAt := updatedDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+				return restartedAt != "" && restartedAt != originalRestartedAt
 			}, timeout, interval).Should(BeTrue())
 
-			By("Verifying the new Pod has correct labels and service account")
-			var newPod corev1.Pod
-			Expect(k8sClient.Get(ctx, podLookupKey, &newPod)).Should(Succeed())
-			Expect(newPod.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, bmcName))
-			Expect(newPod.Labels).To(HaveKeyWithValue(VMNameLabel, vmName))
-			Expect(newPod.Spec.ServiceAccountName).To(Equal(vmName + "-virtbmc"))
+			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VirtualMachineBMCNameLabel, bmcName))
+			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(VMNameLabel, vmName))
+			Expect(updatedDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(vmName + "-virtbmc"))
 		})
 
 		It("Should delete and recreate Pod and patch Service when enableIPMI is changed", func() {

--- a/internal/controller/virtualmachinebmc/bmc_controller_test.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller_test.go
@@ -659,11 +659,11 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(updatedDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(vmName + "-virtbmc"))
 		})
 
-		It("Should delete and recreate Pod and patch Service when enableIPMI is changed", func() {
+		It("Should delete and recreate Deployment and patch Service when enableIPMI is changed", func() {
 			ctx := context.Background()
 
 			By("Getting VirtualMachine and Secret from the first test")
-			podLookupKey := types.NamespacedName{
+			deploymentLookupKey := types.NamespacedName{
 				Name:      testVMName + "-virtbmc",
 				Namespace: testVirtualMachineBMCNamespace,
 			}
@@ -676,20 +676,20 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				Namespace: testVirtualMachineBMCNamespace,
 			}
 
-			var originalPod corev1.Pod
+			var originalDeployment appsv1.Deployment
 			var originalSvc corev1.Service
 			Eventually(func() bool {
-				err1 := k8sClient.Get(ctx, podLookupKey, &originalPod)
+				err1 := k8sClient.Get(ctx, deploymentLookupKey, &originalDeployment)
 				err2 := k8sClient.Get(ctx, svcLookupKey, &originalSvc)
 				return err1 == nil && err2 == nil
 			}, timeout, interval).Should(BeTrue())
 
-			originalPodUID := originalPod.UID
+			originalDeploymentUID := originalDeployment.UID
 			originalSvcUID := originalSvc.UID
 			originalSvcClusterIP := originalSvc.Spec.ClusterIP
 
-			Expect(originalPod.Spec.Containers[0].Ports).To(HaveLen(1))
-			Expect(originalPod.Spec.Containers[0].Ports[0].Name).To(Equal(redfishPortName))
+			Expect(originalDeployment.Spec.Template.Spec.Containers[0].Ports).To(HaveLen(1))
+			Expect(originalDeployment.Spec.Template.Spec.Containers[0].Ports[0].Name).To(Equal(redfishPortName))
 
 			Expect(originalSvc.Spec.Ports).To(HaveLen(1))
 			Expect(originalSvc.Spec.Ports[0].Name).To(Equal(redfishPortName))
@@ -700,30 +700,30 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			updatedBMC.Spec.IPMI = &bmcv1.IPMISpec{Enabled: boolPtr(true)}
 			Expect(k8sClient.Update(ctx, updatedBMC)).Should(Succeed())
 
-			By("Verifying that Pod is recreated (new UID) and Service is patched (same UID) with IPMI ports")
-			var newPod corev1.Pod
+			By("Verifying that Deployment is recreated (new UID) and Service is patched (same UID) with IPMI ports")
+			var newDeployment appsv1.Deployment
 			var newSvc corev1.Service
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, podLookupKey, &newPod); err != nil {
+				if err := k8sClient.Get(ctx, deploymentLookupKey, &newDeployment); err != nil {
 					return false
 				}
 				if err := k8sClient.Get(ctx, svcLookupKey, &newSvc); err != nil {
 					return false
 				}
-				if newPod.UID == originalPodUID {
+				if newDeployment.UID == originalDeploymentUID {
 					return false
 				}
 				if newSvc.UID != originalSvcUID {
 					return false
 				}
-				if len(newPod.Spec.Containers[0].Ports) < 2 || len(newSvc.Spec.Ports) < 2 {
+				if len(newDeployment.Spec.Template.Spec.Containers[0].Ports) < 2 || len(newSvc.Spec.Ports) < 2 {
 					return false
 				}
 				return true
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(newPod.Spec.Containers[0].Ports).To(HaveLen(2))
-			portNames := []string{newPod.Spec.Containers[0].Ports[0].Name, newPod.Spec.Containers[0].Ports[1].Name}
+			Expect(newDeployment.Spec.Template.Spec.Containers[0].Ports).To(HaveLen(2))
+			portNames := []string{newDeployment.Spec.Template.Spec.Containers[0].Ports[0].Name, newDeployment.Spec.Template.Spec.Containers[0].Ports[1].Name}
 			Expect(portNames).To(ContainElement(redfishPortName))
 			Expect(portNames).To(ContainElement(ipmiPortName))
 

--- a/internal/controller/virtualmachinebmc/bmc_controller_test.go
+++ b/internal/controller/virtualmachinebmc/bmc_controller_test.go
@@ -627,10 +627,11 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			originalRestartedAt := ""
+			originalSecretHash := ""
 			if originalDeployment.Spec.Template.Annotations != nil {
-				originalRestartedAt = originalDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+				originalSecretHash = originalDeployment.Spec.Template.Annotations[SecretHashAnnotation]
 			}
+			Expect(originalSecretHash).NotTo(BeEmpty())
 
 			By("Updating the Secret with new credentials")
 			updatedSecret := &corev1.Secret{}
@@ -641,7 +642,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, updatedSecret)).Should(Succeed())
 
-			By("Verifying the Deployment template gets a restart annotation")
+			By("Verifying the Deployment template gets a new secret-hash annotation, triggering a rollout")
 			var updatedDeployment appsv1.Deployment
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx, deploymentLookupKey, &updatedDeployment); err != nil {
@@ -650,8 +651,8 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				if updatedDeployment.Spec.Template.Annotations == nil {
 					return false
 				}
-				restartedAt := updatedDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
-				return restartedAt != "" && restartedAt != originalRestartedAt
+				secretHash := updatedDeployment.Spec.Template.Annotations[SecretHashAnnotation]
+				return secretHash != "" && secretHash != originalSecretHash
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(updatedDeployment.Spec.Template.Labels).To(HaveKeyWithValue(bmcv1.VirtualMachineBMCNameLabel, bmcName))
@@ -659,7 +660,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			Expect(updatedDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(vmName + "-virtbmc"))
 		})
 
-		It("Should delete and recreate Deployment and patch Service when enableIPMI is changed", func() {
+		It("Should update Deployment in place and patch Service when enableIPMI is changed", func() {
 			ctx := context.Background()
 
 			By("Getting VirtualMachine and Secret from the first test")
@@ -700,7 +701,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 			updatedBMC.Spec.IPMI = &bmcv1.IPMISpec{Enabled: boolPtr(true)}
 			Expect(k8sClient.Update(ctx, updatedBMC)).Should(Succeed())
 
-			By("Verifying that Deployment is recreated (new UID) and Service is patched (same UID) with IPMI ports")
+			By("Verifying that Deployment is updated in place (same UID) and Service is patched (same UID) with IPMI ports")
 			var newDeployment appsv1.Deployment
 			var newSvc corev1.Service
 			Eventually(func() bool {
@@ -710,7 +711,7 @@ var _ = Describe("VirtualMachineBMC Controller", func() {
 				if err := k8sClient.Get(ctx, svcLookupKey, &newSvc); err != nil {
 					return false
 				}
-				if newDeployment.UID == originalDeploymentUID {
+				if newDeployment.UID != originalDeploymentUID {
 					return false
 				}
 				if newSvc.UID != originalSvcUID {

--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -1,5 +1,7 @@
 package virtualmachinebmc
 
+import bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+
 const (
 	DefaultUsername            = "admin"
 	DefaultPassword            = "password"
@@ -13,7 +15,7 @@ const (
 	RedfishSvcPort             = 80
 	ipmiPortName               = "ipmi"
 	redfishPortName            = "redfish"
-	VirtualMachineBMCNameLabel = "kubevirt.io/virtualmachinebmc-name"
+	VirtualMachineBMCNameLabel = bmcv1.VirtualMachineBMCNameLabel
 	VMNameLabel                = "kubevirt.io/vm-name"
 	VirtualMachineBMCNamespace = "kubevirtbmc-system"
 	EnableIPMIAnnotation       = "bmc.kubevirt.io/enable-ipmi"

--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -15,4 +15,5 @@ const (
 	redfishPortName            = "redfish"
 	VirtualMachineBMCNamespace = "kubevirtbmc-system"
 	EnableIPMIAnnotation       = "bmc.kubevirt.io/enable-ipmi"
+	SecretHashAnnotation       = "bmc.kubevirt.io/secret-hash"
 )

--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -1,22 +1,20 @@
 package virtualmachinebmc
 
-import bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
-
 const (
-	DefaultUsername            = "admin"
-	DefaultPassword            = "password"
-	DefaultAgentCPURequest     = "10m"
-	DefaultAgentMemoryRequest  = "128Mi"
-	virtBMCContainerName       = "virtbmc"
-	VirtBMCImageName           = "kubevirtbmc/virtbmc"
-	ipmiPort                   = 10623
-	redfishPort                = 10080
-	IPMISvcPort                = 623
-	RedfishSvcPort             = 80
-	ipmiPortName               = "ipmi"
-	redfishPortName            = "redfish"
-	VirtualMachineBMCNameLabel = bmcv1.VirtualMachineBMCNameLabel
-	VMNameLabel                = "kubevirt.io/vm-name"
+	DefaultUsername           = "admin"
+	DefaultPassword           = "password"
+	DefaultAgentCPURequest    = "10m"
+	DefaultAgentMemoryRequest = "128Mi"
+	virtBMCContainerName      = "virtbmc"
+	VirtBMCImageName          = "kubevirtbmc/virtbmc"
+	ipmiPort                  = 10623
+	redfishPort               = 10080
+	IPMISvcPort               = 623
+	RedfishSvcPort            = 80
+	ipmiPortName              = "ipmi"
+	redfishPortName           = "redfish"
+	//VirtualMachineBMCNameLabel = bmcv1.VirtualMachineBMCNameLabel
+	//VMNameLabel                = "kubevirt.io/vm-name"
 	VirtualMachineBMCNamespace = "kubevirtbmc-system"
 	EnableIPMIAnnotation       = "bmc.kubevirt.io/enable-ipmi"
 )

--- a/internal/controller/virtualmachinebmc/constant.go
+++ b/internal/controller/virtualmachinebmc/constant.go
@@ -1,20 +1,18 @@
 package virtualmachinebmc
 
 const (
-	DefaultUsername           = "admin"
-	DefaultPassword           = "password"
-	DefaultAgentCPURequest    = "10m"
-	DefaultAgentMemoryRequest = "128Mi"
-	virtBMCContainerName      = "virtbmc"
-	VirtBMCImageName          = "kubevirtbmc/virtbmc"
-	ipmiPort                  = 10623
-	redfishPort               = 10080
-	IPMISvcPort               = 623
-	RedfishSvcPort            = 80
-	ipmiPortName              = "ipmi"
-	redfishPortName           = "redfish"
-	//VirtualMachineBMCNameLabel = bmcv1.VirtualMachineBMCNameLabel
-	//VMNameLabel                = "kubevirt.io/vm-name"
+	DefaultUsername            = "admin"
+	DefaultPassword            = "password"
+	DefaultAgentCPURequest     = "10m"
+	DefaultAgentMemoryRequest  = "128Mi"
+	virtBMCContainerName       = "virtbmc"
+	VirtBMCImageName           = "kubevirtbmc/virtbmc"
+	ipmiPort                   = 10623
+	redfishPort                = 10080
+	IPMISvcPort                = 623
+	RedfishSvcPort             = 80
+	ipmiPortName               = "ipmi"
+	redfishPortName            = "redfish"
 	VirtualMachineBMCNamespace = "kubevirtbmc-system"
 	EnableIPMIAnnotation       = "bmc.kubevirt.io/enable-ipmi"
 )

--- a/internal/controller/virtualmachinebmc/deployment.go
+++ b/internal/controller/virtualmachinebmc/deployment.go
@@ -265,6 +265,33 @@ func (r *VirtualMachineBMCReconciler) getVirtBMCDeployment(ctx context.Context, 
 	return deployment, nil
 }
 
+// Note: This function needs to be cleaned up in future releases once we are confident that all users have
+// upgraded to the newer release.
+func (r *VirtualMachineBMCReconciler) deleteLegacyVirtBMCPod(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
+	log := log.FromContext(ctx)
+	podName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+
+	pod := &corev1.Pod{}
+	if err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: virtualMachineBMC.Namespace}, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if !metav1.IsControlledBy(pod, virtualMachineBMC) {
+		return nil
+	}
+
+	if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "unable to delete legacy virtBMC Pod", "pod", podName)
+		return err
+	}
+
+	log.Info("deleted legacy virtBMC Pod", "pod", podName)
+	return nil
+}
+
 func int32Ptr(i int32) *int32 {
 	return &i
 }

--- a/internal/controller/virtualmachinebmc/deployment.go
+++ b/internal/controller/virtualmachinebmc/deployment.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualmachinebmc
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+)
+
+const (
+	defaultDesiredReplicas int32 = 1
+)
+
+func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC *bmcv1.VirtualMachineBMC) *appsv1.Deployment {
+
+	serviceAccountName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+	deploymentName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+
+	var secretName string
+	if virtualMachineBMC.Spec.AuthSecretRef != nil {
+		secretName = virtualMachineBMC.Spec.AuthSecretRef.Name
+	}
+
+	labels := map[string]string{
+		VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
+		VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: virtualMachineBMC.Namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(defaultDesiredReplicas),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+					Annotations: map[string]string{
+						EnableIPMIAnnotation: strconv.FormatBool(specIPMIEnabled(&virtualMachineBMC.Spec)),
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccountName,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  virtBMCContainerName,
+							Image: fmt.Sprintf("%s:%s", r.AgentImageName, r.AgentImageTag),
+							Args: func() []string {
+								args := []string{
+									"--address",
+									"0.0.0.0",
+									"--redfish-port",
+									strconv.Itoa(redfishPort),
+								}
+								if specIPMIEnabled(&virtualMachineBMC.Spec) {
+									args = append(args, "--enable-ipmi", "--ipmi-port", strconv.Itoa(ipmiPort))
+								}
+								args = append(args, virtualMachineBMC.Namespace, virtualMachineBMC.Spec.VirtualMachineRef.Name)
+								return args
+							}(),
+							Ports: func() []corev1.ContainerPort {
+								ports := []corev1.ContainerPort{
+									{
+										Name:          redfishPortName,
+										ContainerPort: redfishPort,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								}
+								if specIPMIEnabled(&virtualMachineBMC.Spec) {
+									ports = append(ports, corev1.ContainerPort{
+										Name:          ipmiPortName,
+										ContainerPort: ipmiPort,
+										Protocol:      corev1.ProtocolUDP,
+									})
+								}
+								return ports
+							}(),
+							Env: []corev1.EnvVar{
+								{
+									Name: "BMC_USERNAME",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: secretName,
+											},
+											Key: bmcUserKey,
+										},
+									},
+								},
+								{
+									Name: "BMC_PASSWORD",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: secretName,
+											},
+											Key: bmcPasswordKey,
+										},
+									},
+								},
+								{
+									Name: "POD_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/redfish/v1",
+										Port: intstr.FromString(redfishPortName),
+									},
+								},
+								InitialDelaySeconds: 2,
+								PeriodSeconds:       10,
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: r.agentResourceRequests(),
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								ReadOnlyRootFilesystem:   ptr.To(true),
+								RunAsNonRoot:             ptr.To(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+func (r *VirtualMachineBMCReconciler) ensureVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
+	log := log.FromContext(ctx)
+
+	desiredDeployment := r.createVirtBMCDeployment(virtualMachineBMC)
+	if err := ctrl.SetControllerReference(virtualMachineBMC, desiredDeployment, r.Scheme); err != nil {
+		return err
+	}
+
+	if err := r.Create(ctx, desiredDeployment); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existingDeployment, getErr := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
+			if getErr != nil {
+				return getErr
+			}
+			if existingDeployment == nil {
+				return nil
+			}
+
+			restartedAt := ""
+			if existingDeployment.Spec.Template.Annotations != nil {
+				restartedAt = existingDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+			}
+
+			changed := false
+			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec, desiredDeployment.Spec.Template.Spec) {
+				existingDeployment.Spec.Template.Spec = desiredDeployment.Spec.Template.Spec
+				changed = true
+			}
+			if restartedAt != "" {
+				desiredAnnotations := map[string]string{
+					"kubectl.kubernetes.io/restartedAt": restartedAt,
+				}
+				if !reflect.DeepEqual(existingDeployment.Spec.Template.Annotations, desiredAnnotations) {
+					existingDeployment.Spec.Template.Annotations = desiredAnnotations
+					changed = true
+				}
+			} else {
+				if existingDeployment.Spec.Template.Annotations != nil {
+					existingDeployment.Spec.Template.Annotations = nil
+					changed = true
+				}
+			}
+
+			if !changed {
+				return nil
+			}
+
+			if err := r.Update(ctx, existingDeployment); err != nil {
+				log.Error(err, "unable to reconcile Deployment for VirtualMachineBMC", "deployment", existingDeployment.Name)
+				return err
+			}
+			log.V(1).Info("reconciled Deployment for VirtualMachineBMC", "deployment", existingDeployment.Name)
+			return nil
+		}
+		log.Error(err, "unable to create Deployment for VirtualMachineBMC", "deployment", desiredDeployment.Name)
+		return err
+	}
+
+	log.V(1).Info("created Deployment for VirtualMachineBMC", "deployment", desiredDeployment.Name)
+	return nil
+}
+
+func (r *VirtualMachineBMCReconciler) deleteVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
+	log := log.FromContext(ctx)
+	deployment, err := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
+	if err != nil {
+		return err
+	}
+
+	if deployment == nil {
+		return nil
+	}
+
+	if err := r.Delete(ctx, deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		log.Error(err, "unable to delete virtBMC Deployment", "deployment", deployment)
+		return err
+	}
+
+	log.Info("deleted virtBMC Deployment", "deployment", deployment)
+	return nil
+}
+
+func (r *VirtualMachineBMCReconciler) rolloutRestartVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
+
+	log := log.FromContext(ctx)
+	deployment, err := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
+	if err != nil {
+		return err
+	}
+
+	if deployment == nil {
+		return nil
+	}
+
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+
+	deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+	if err := r.Update(ctx, deployment); err != nil {
+		log.Error(err, "unable to rollout restart virtBMC Deployment", "deployment", appsv1.DeploymentAvailable)
+		return err
+	}
+
+	log.Info("triggered rollout restart for virtBMC Deployment", "deployment", deployment)
+	return nil
+}
+
+func (r *VirtualMachineBMCReconciler) getVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (*appsv1.Deployment, error) {
+	log := log.FromContext(ctx)
+	deploymentName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
+
+	deployment := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      deploymentName,
+		Namespace: virtualMachineBMC.Namespace,
+	}, deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		log.Error(err, "unable to get virtBMC Deployment", "deployment", deploymentName)
+		return nil, err
+	}
+
+	return deployment, nil
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}

--- a/internal/controller/virtualmachinebmc/deployment.go
+++ b/internal/controller/virtualmachinebmc/deployment.go
@@ -185,10 +185,6 @@ func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC 
 	return deployment
 }
 
-// authSecretHash returns a hash of the referenced auth Secret's credentials,
-// so it can be stamped onto the Deployment's pod template. A change in the
-// hash changes the pod template, which the Deployment controller rolls out
-// on its own, without any manual restart.
 func (r *VirtualMachineBMCReconciler) authSecretHash(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (string, error) {
 	if virtualMachineBMC.Spec.AuthSecretRef == nil {
 		return "", nil

--- a/internal/controller/virtualmachinebmc/deployment.go
+++ b/internal/controller/virtualmachinebmc/deployment.go
@@ -52,8 +52,8 @@ func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC 
 	}
 
 	labels := map[string]string{
-		VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
-		VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
+		bmcv1.VirtualMachineBMCNameLabel: virtualMachineBMC.Name,
+		bmcv1.VMNameLabel:                virtualMachineBMC.Spec.VirtualMachineRef.Name,
 	}
 
 	deployment := &appsv1.Deployment{

--- a/internal/controller/virtualmachinebmc/deployment.go
+++ b/internal/controller/virtualmachinebmc/deployment.go
@@ -18,9 +18,10 @@ package virtualmachinebmc
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strconv"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,7 +42,7 @@ const (
 	fieldManager                 = "kubevirtbmc-controller"
 )
 
-func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC *bmcv1.VirtualMachineBMC) *appsv1.Deployment {
+func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC *bmcv1.VirtualMachineBMC, secretHash string) *appsv1.Deployment {
 
 	serviceAccountName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
 	deploymentName := fmt.Sprintf("%s-virtbmc", virtualMachineBMC.Spec.VirtualMachineRef.Name)
@@ -63,16 +64,22 @@ func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC 
 			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(defaultDesiredReplicas),
+			Replicas: ptr.To(defaultDesiredReplicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
-					Annotations: map[string]string{
-						EnableIPMIAnnotation: strconv.FormatBool(specIPMIEnabled(&virtualMachineBMC.Spec)),
-					},
+					Annotations: func() map[string]string {
+						annotations := map[string]string{
+							EnableIPMIAnnotation: strconv.FormatBool(specIPMIEnabled(&virtualMachineBMC.Spec)),
+						}
+						if secretHash != "" {
+							annotations[SecretHashAnnotation] = secretHash
+						}
+						return annotations
+					}(),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccountName,
@@ -178,10 +185,41 @@ func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC 
 	return deployment
 }
 
+// authSecretHash returns a hash of the referenced auth Secret's credentials,
+// so it can be stamped onto the Deployment's pod template. A change in the
+// hash changes the pod template, which the Deployment controller rolls out
+// on its own, without any manual restart.
+func (r *VirtualMachineBMCReconciler) authSecretHash(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) (string, error) {
+	if virtualMachineBMC.Spec.AuthSecretRef == nil {
+		return "", nil
+	}
+
+	var secret corev1.Secret
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      virtualMachineBMC.Spec.AuthSecretRef.Name,
+		Namespace: virtualMachineBMC.Namespace,
+	}, &secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	h := sha256.New()
+	h.Write(secret.Data[bmcUserKey])
+	h.Write(secret.Data[bmcPasswordKey])
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
 func (r *VirtualMachineBMCReconciler) ensureVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
 	log := log.FromContext(ctx)
 
-	desired := r.createVirtBMCDeployment(virtualMachineBMC)
+	secretHash, err := r.authSecretHash(ctx, virtualMachineBMC)
+	if err != nil {
+		return err
+	}
+
+	desired := r.createVirtBMCDeployment(virtualMachineBMC, secretHash)
 	desired.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
 	if err := ctrl.SetControllerReference(virtualMachineBMC, desired, r.Scheme); err != nil {
 		return err
@@ -216,33 +254,6 @@ func (r *VirtualMachineBMCReconciler) deleteVirtBMCDeployment(ctx context.Contex
 	}
 
 	log.Info("deleted virtBMC Deployment", "deployment", deployment)
-	return nil
-}
-
-func (r *VirtualMachineBMCReconciler) rolloutRestartVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
-
-	log := log.FromContext(ctx)
-	deployment, err := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
-	if err != nil {
-		return err
-	}
-
-	if deployment == nil {
-		return nil
-	}
-
-	if deployment.Spec.Template.Annotations == nil {
-		deployment.Spec.Template.Annotations = map[string]string{}
-	}
-
-	deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
-
-	if err := r.Update(ctx, deployment); err != nil {
-		log.Error(err, "unable to rollout restart virtBMC Deployment", "deployment", appsv1.DeploymentAvailable)
-		return err
-	}
-
-	log.Info("triggered rollout restart for virtBMC Deployment", "deployment", deployment)
 	return nil
 }
 
@@ -290,8 +301,4 @@ func (r *VirtualMachineBMCReconciler) deleteLegacyVirtBMCPod(ctx context.Context
 
 	log.Info("deleted legacy virtBMC Pod", "pod", podName)
 	return nil
-}
-
-func int32Ptr(i int32) *int32 {
-	return &i
 }

--- a/internal/controller/virtualmachinebmc/deployment.go
+++ b/internal/controller/virtualmachinebmc/deployment.go
@@ -19,7 +19,6 @@ package virtualmachinebmc
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
@@ -38,6 +38,7 @@ import (
 
 const (
 	defaultDesiredReplicas int32 = 1
+	fieldManager                 = "kubevirtbmc-controller"
 )
 
 func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC *bmcv1.VirtualMachineBMC) *appsv1.Deployment {
@@ -180,62 +181,18 @@ func (r *VirtualMachineBMCReconciler) createVirtBMCDeployment(virtualMachineBMC 
 func (r *VirtualMachineBMCReconciler) ensureVirtBMCDeployment(ctx context.Context, virtualMachineBMC *bmcv1.VirtualMachineBMC) error {
 	log := log.FromContext(ctx)
 
-	desiredDeployment := r.createVirtBMCDeployment(virtualMachineBMC)
-	if err := ctrl.SetControllerReference(virtualMachineBMC, desiredDeployment, r.Scheme); err != nil {
+	desired := r.createVirtBMCDeployment(virtualMachineBMC)
+	desired.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+	if err := ctrl.SetControllerReference(virtualMachineBMC, desired, r.Scheme); err != nil {
 		return err
 	}
 
-	if err := r.Create(ctx, desiredDeployment); err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			existingDeployment, getErr := r.getVirtBMCDeployment(ctx, virtualMachineBMC)
-			if getErr != nil {
-				return getErr
-			}
-			if existingDeployment == nil {
-				return nil
-			}
-
-			restartedAt := ""
-			if existingDeployment.Spec.Template.Annotations != nil {
-				restartedAt = existingDeployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
-			}
-
-			changed := false
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec, desiredDeployment.Spec.Template.Spec) {
-				existingDeployment.Spec.Template.Spec = desiredDeployment.Spec.Template.Spec
-				changed = true
-			}
-			if restartedAt != "" {
-				desiredAnnotations := map[string]string{
-					"kubectl.kubernetes.io/restartedAt": restartedAt,
-				}
-				if !reflect.DeepEqual(existingDeployment.Spec.Template.Annotations, desiredAnnotations) {
-					existingDeployment.Spec.Template.Annotations = desiredAnnotations
-					changed = true
-				}
-			} else {
-				if existingDeployment.Spec.Template.Annotations != nil {
-					existingDeployment.Spec.Template.Annotations = nil
-					changed = true
-				}
-			}
-
-			if !changed {
-				return nil
-			}
-
-			if err := r.Update(ctx, existingDeployment); err != nil {
-				log.Error(err, "unable to reconcile Deployment for VirtualMachineBMC", "deployment", existingDeployment.Name)
-				return err
-			}
-			log.V(1).Info("reconciled Deployment for VirtualMachineBMC", "deployment", existingDeployment.Name)
-			return nil
-		}
-		log.Error(err, "unable to create Deployment for VirtualMachineBMC", "deployment", desiredDeployment.Name)
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldManager), client.ForceOwnership); err != nil {
+		log.Error(err, "unable to apply Deployment for VirtualMachineBMC", "deployment", desired.Name)
 		return err
 	}
 
-	log.V(1).Info("created Deployment for VirtualMachineBMC", "deployment", desiredDeployment.Name)
+	log.V(1).Info("applied Deployment for VirtualMachineBMC", "deployment", desired.Name)
 	return nil
 }
 

--- a/pkg/virtbmc/virtbmc.go
+++ b/pkg/virtbmc/virtbmc.go
@@ -85,7 +85,6 @@ func NewVirtBMC(ctx context.Context, options Options, inCluster bool) (*VirtBMC,
 	}, nil
 }
 
-// Resolved via label, not ownerReferences: the agent Pod is owned by a ReplicaSet, not the VirtualMachineBMC directly.
 func virtualMachineBMCNameFromPodLabel(ctx context.Context, bmcClient client.Client, namespace, podName string) (string, error) {
 	if podName == "" {
 		return "", fmt.Errorf("POD_NAME is required to resolve VirtualMachineBMC owner")

--- a/pkg/virtbmc/virtbmc.go
+++ b/pkg/virtbmc/virtbmc.go
@@ -10,15 +10,11 @@ import (
 	kvclient "kubevirt.io/client-go/kubevirt"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
 	"kubevirt.io/kubevirtbmc/pkg/ipmi"
 	"kubevirt.io/kubevirtbmc/pkg/redfish"
 	"kubevirt.io/kubevirtbmc/pkg/resourcemanager"
 )
-
-// virtualMachineBMCNameLabel must match virtualMachineBMCNameLabel.
-// Duplicated here (rather than imported) because Dockerfile.virtbmc only
-// copies api/ and pkg/ into the agent's build context, not internal/.
-const virtualMachineBMCNameLabel = "kubevirt.io/virtualmachinebmc-name"
 
 type VMNameKey struct{}
 
@@ -89,8 +85,7 @@ func NewVirtBMC(ctx context.Context, options Options, inCluster bool) (*VirtBMC,
 	}, nil
 }
 
-// The agent Pod is owned by a ReplicaSet, not directly by the
-// VirtualMachineBMC, so we resolve via label instead of ownerReferences.
+// Resolved via label, not ownerReferences: the agent Pod is owned by a ReplicaSet, not the VirtualMachineBMC directly.
 func virtualMachineBMCNameFromPodLabel(ctx context.Context, bmcClient client.Client, namespace, podName string) (string, error) {
 	if podName == "" {
 		return "", fmt.Errorf("POD_NAME is required to resolve VirtualMachineBMC owner")
@@ -101,12 +96,12 @@ func virtualMachineBMCNameFromPodLabel(ctx context.Context, bmcClient client.Cli
 		return "", fmt.Errorf("failed to get own pod %s/%s: %w", namespace, podName, err)
 	}
 
-	if name, ok := pod.Labels[virtualMachineBMCNameLabel]; ok && name != "" {
+	if name, ok := pod.Labels[bmcv1.VirtualMachineBMCNameLabel]; ok && name != "" {
 		return name, nil
 	}
 
 	return "", fmt.Errorf("pod %s/%s has no %s label identifying its VirtualMachineBMC",
-		namespace, podName, virtualMachineBMCNameLabel)
+		namespace, podName, bmcv1.VirtualMachineBMCNameLabel)
 }
 
 func (b *VirtBMC) Run() error {

--- a/pkg/virtbmc/virtbmc.go
+++ b/pkg/virtbmc/virtbmc.go
@@ -10,11 +10,15 @@ import (
 	kvclient "kubevirt.io/client-go/kubevirt"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
 	"kubevirt.io/kubevirtbmc/pkg/ipmi"
 	"kubevirt.io/kubevirtbmc/pkg/redfish"
 	"kubevirt.io/kubevirtbmc/pkg/resourcemanager"
 )
+
+// virtualMachineBMCNameLabel must match virtualMachineBMCNameLabel.
+// Duplicated here (rather than imported) because Dockerfile.virtbmc only
+// copies api/ and pkg/ into the agent's build context, not internal/.
+const virtualMachineBMCNameLabel = "kubevirt.io/virtualmachinebmc-name"
 
 type VMNameKey struct{}
 
@@ -57,7 +61,7 @@ func NewVirtBMC(ctx context.Context, options Options, inCluster bool) (*VirtBMC,
 
 	vmNamespace := ctx.Value(VMNamespaceKey{}).(string)
 	vmName := ctx.Value(VMNameKey{}).(string)
-	bmcName, err := virtualMachineBMCNameFromPodOwner(ctx, bmcClient, vmNamespace, options.PodName)
+	bmcName, err := virtualMachineBMCNameFromPodLabel(ctx, bmcClient, vmNamespace, options.PodName)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +89,9 @@ func NewVirtBMC(ctx context.Context, options Options, inCluster bool) (*VirtBMC,
 	}, nil
 }
 
-func virtualMachineBMCNameFromPodOwner(ctx context.Context, bmcClient client.Client, namespace, podName string) (string, error) {
+// The agent Pod is owned by a ReplicaSet, not directly by the
+// VirtualMachineBMC, so we resolve via label instead of ownerReferences.
+func virtualMachineBMCNameFromPodLabel(ctx context.Context, bmcClient client.Client, namespace, podName string) (string, error) {
 	if podName == "" {
 		return "", fmt.Errorf("POD_NAME is required to resolve VirtualMachineBMC owner")
 	}
@@ -95,13 +101,12 @@ func virtualMachineBMCNameFromPodOwner(ctx context.Context, bmcClient client.Cli
 		return "", fmt.Errorf("failed to get own pod %s/%s: %w", namespace, podName, err)
 	}
 
-	for _, owner := range pod.OwnerReferences {
-		if owner.APIVersion == bmcv1.GroupVersion.String() && owner.Kind == "VirtualMachineBMC" {
-			return owner.Name, nil
-		}
+	if name, ok := pod.Labels[virtualMachineBMCNameLabel]; ok && name != "" {
+		return name, nil
 	}
 
-	return "", fmt.Errorf("pod %s/%s has no VirtualMachineBMC ownerReference", namespace, podName)
+	return "", fmt.Errorf("pod %s/%s has no %s label identifying its VirtualMachineBMC",
+		namespace, podName, virtualMachineBMCNameLabel)
 }
 
 func (b *VirtBMC) Run() error {

--- a/test/util/e2e_resources.go
+++ b/test/util/e2e_resources.go
@@ -40,17 +40,12 @@ func AgentServiceKey(namespace string) types.NamespacedName {
 	return types.NamespacedName{Name: E2EAgentDeploymentName, Namespace: namespace}
 }
 
-// agentPodLabels selects the single Pod owned by the agent Deployment for the
-// default E2E VirtualMachineBMC/VM pair. Deployment-managed Pods get a
-// generated name, so callers that need the live Pod (e.g. to observe its UID)
-// must look it up by label rather than by a fixed name.
 var agentPodLabels = client.MatchingLabels{
 	"kubevirt.io/virtualmachinebmc-name": E2EBMCName,
 	"kubevirt.io/vm-name":                E2EVMName,
 }
 
-// AgentPod returns the single running Pod backing the agent Deployment in the
-// given namespace. It errors if zero or more than one Pod matches.
+// AgentPod errors unless exactly one Pod matches, since Deployment-managed Pods have a generated name.
 func AgentPod(ctx context.Context, k8sClient client.Client, namespace string) (*corev1.Pod, error) {
 	var podList corev1.PodList
 	if err := k8sClient.List(ctx, &podList, client.InNamespace(namespace), agentPodLabels); err != nil {

--- a/test/util/e2e_resources.go
+++ b/test/util/e2e_resources.go
@@ -41,8 +41,8 @@ func AgentServiceKey(namespace string) types.NamespacedName {
 }
 
 var agentPodLabels = client.MatchingLabels{
-	"kubevirt.io/virtualmachinebmc-name": E2EBMCName,
-	"kubevirt.io/vm-name":                E2EVMName,
+	bmcv1.VirtualMachineBMCNameLabel: E2EBMCName,
+	bmcv1.VMNameLabel:                E2EVMName,
 }
 
 // AgentPod errors unless exactly one Pod matches, since Deployment-managed Pods have a generated name.

--- a/test/util/e2e_resources.go
+++ b/test/util/e2e_resources.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,14 +26,40 @@ const (
 	E2ESecretName              = "bmc-credentials-secret"
 	E2EBMCName                 = "test-bmc"
 	E2ENamespace               = "default"
-	E2EAgentPodName            = E2EVMName + "-virtbmc"
+	E2EAgentDeploymentName     = E2EVMName + "-virtbmc"
 	E2EWebhookServiceName      = "kubevirtbmc-webhook-service"
 	E2EWebhookServiceNamespace = "kubevirtbmc-system"
 	WebhookRegistrationDelay   = 10 * time.Second
 )
 
-func AgentPodKey(namespace string) types.NamespacedName {
-	return types.NamespacedName{Name: E2EAgentPodName, Namespace: namespace}
+func AgentDeploymentKey(namespace string) types.NamespacedName {
+	return types.NamespacedName{Name: E2EAgentDeploymentName, Namespace: namespace}
+}
+
+func AgentServiceKey(namespace string) types.NamespacedName {
+	return types.NamespacedName{Name: E2EAgentDeploymentName, Namespace: namespace}
+}
+
+// agentPodLabels selects the single Pod owned by the agent Deployment for the
+// default E2E VirtualMachineBMC/VM pair. Deployment-managed Pods get a
+// generated name, so callers that need the live Pod (e.g. to observe its UID)
+// must look it up by label rather than by a fixed name.
+var agentPodLabels = client.MatchingLabels{
+	"kubevirt.io/virtualmachinebmc-name": E2EBMCName,
+	"kubevirt.io/vm-name":                E2EVMName,
+}
+
+// AgentPod returns the single running Pod backing the agent Deployment in the
+// given namespace. It errors if zero or more than one Pod matches.
+func AgentPod(ctx context.Context, k8sClient client.Client, namespace string) (*corev1.Pod, error) {
+	var podList corev1.PodList
+	if err := k8sClient.List(ctx, &podList, client.InNamespace(namespace), agentPodLabels); err != nil {
+		return nil, err
+	}
+	if len(podList.Items) != 1 {
+		return nil, apierrors.NewNotFound(corev1.Resource("pods"), E2EAgentDeploymentName)
+	}
+	return &podList.Items[0], nil
 }
 
 func BMCKey(namespace string) types.NamespacedName {
@@ -54,42 +81,46 @@ func HasBMCCondition(ctx context.Context, k8sClient client.Client, namespace, co
 	}
 }
 
-func PodExists(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
+func DeploymentReady(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
 	return func() bool {
-		pod := &corev1.Pod{}
-		return k8sClient.Get(ctx, AgentPodKey(namespace), pod) == nil
+		deployment := &appsv1.Deployment{}
+		if err := k8sClient.Get(ctx, AgentDeploymentKey(namespace), deployment); err != nil {
+			return false
+		}
+
+		desiredReplicas := int32(1)
+		if deployment.Spec.Replicas != nil {
+			desiredReplicas = *deployment.Spec.Replicas
+		}
+
+		if deployment.Status.ObservedGeneration < deployment.Generation {
+			return false
+		}
+
+		return deployment.Status.UpdatedReplicas >= desiredReplicas &&
+			deployment.Status.ReadyReplicas >= desiredReplicas &&
+			deployment.Status.AvailableReplicas >= desiredReplicas
 	}
 }
 
-func PodNotFound(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
+func DeploymentExists(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
 	return func() bool {
-		pod := &corev1.Pod{}
-		return apierrors.IsNotFound(k8sClient.Get(ctx, AgentPodKey(namespace), pod))
+		deployment := &appsv1.Deployment{}
+		return k8sClient.Get(ctx, AgentDeploymentKey(namespace), deployment) == nil
 	}
 }
 
-func PodRunningAndReady(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
+func DeploymentNotFound(ctx context.Context, k8sClient client.Client, namespace string) func() bool {
 	return func() bool {
-		pod := &corev1.Pod{}
-		if err := k8sClient.Get(ctx, AgentPodKey(namespace), pod); err != nil {
-			return false
-		}
-		if pod.Status.Phase != corev1.PodRunning {
-			return false
-		}
-		for _, cond := range pod.Status.Conditions {
-			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-				return true
-			}
-		}
-		return false
+		deployment := &appsv1.Deployment{}
+		return apierrors.IsNotFound(k8sClient.Get(ctx, AgentDeploymentKey(namespace), deployment))
 	}
 }
 
 func PodRunningAndReadyWithNewUID(ctx context.Context, k8sClient client.Client, namespace string, oldUID types.UID) func() bool {
 	return func() bool {
-		pod := &corev1.Pod{}
-		if err := k8sClient.Get(ctx, AgentPodKey(namespace), pod); err != nil {
+		pod, err := AgentPod(ctx, k8sClient, namespace)
+		if err != nil {
 			return false
 		}
 		if pod.UID == oldUID {
@@ -232,9 +263,9 @@ func EnsureTestVMSecretBMC(ctx context.Context, k8sClient client.Client, namespa
 		}
 	}
 
-	By("waiting for VMI to reach Running and agent pod to become ready")
+	By("waiting for VMI to reach Running and agent Deployment to become ready")
 	Eventually(VMIRunning(ctx, k8sClient, E2EVMName, namespace), timeout, interval).Should(BeTrue(), "VMI %s/%s should reach Running", namespace, E2EVMName)
-	Eventually(PodRunningAndReady(ctx, k8sClient, namespace), timeout, interval).Should(BeTrue(), "agent pod %s/%s should become ready", namespace, E2EAgentPodName)
+	Eventually(DeploymentReady(ctx, k8sClient, namespace), timeout, interval).Should(BeTrue(), "agent Deployment %s/%s should become ready", namespace, E2EAgentDeploymentName)
 	return nil
 }
 

--- a/test/virtbmc-agent/agent_helpers.go
+++ b/test/virtbmc-agent/agent_helpers.go
@@ -12,6 +12,7 @@ import (
 	kvclient "kubevirt.io/client-go/kubevirt"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,7 @@ const (
 	ipmitoolImage       = "kubevirtbmc/ipmitool:latest" // ipmitool v1.8.19
 	agentTestTimeout    = 60 * time.Second
 	agentTestInterval   = 250 * time.Millisecond
-	agentPodName        = "testvm-virtbmc"
+	agentDeploymentName = "testvm-virtbmc"
 	// suiteInitTimeout covers container disk image pull during suite setup.
 	suiteInitTimeout     = 180 * time.Second
 	vmPowerStatusTimeout = 120 * time.Second
@@ -87,7 +88,7 @@ func ensureAgentTestEnv(ctx context.Context, namespace string, k8sClient client.
 		return nil, err
 	}
 
-	waitForAgentPodReady(ctx, k8sClient, namespace, agentPodName)
+	waitForAgentDeploymentReady(ctx, k8sClient, namespace, agentDeploymentName)
 
 	return env, nil
 }
@@ -508,19 +509,26 @@ func (e *agentTestEnv) ensureBMCExists(ctx context.Context, k8sClient client.Cli
 	return k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: agentBMCName}, e.BMC)
 }
 
-func waitForAgentPodReady(ctx context.Context, k8sClient client.Client, namespace, podName string) {
+func waitForAgentDeploymentReady(ctx context.Context, k8sClient client.Client, namespace, deploymentName string) {
 	Eventually(func() bool {
-		var pod corev1.Pod
-		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: podName}, &pod); err != nil {
+		var deployment appsv1.Deployment
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: deploymentName}, &deployment); err != nil {
 			return false
 		}
-		for _, c := range pod.Status.Conditions {
-			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
-				return true
-			}
+
+		desiredReplicas := int32(1)
+		if deployment.Spec.Replicas != nil {
+			desiredReplicas = *deployment.Spec.Replicas
 		}
-		return false
-	}, agentTestTimeout, agentTestInterval).Should(BeTrue(), "agent pod %q should become ready", podName)
+
+		if deployment.Status.ObservedGeneration < deployment.Generation {
+			return false
+		}
+
+		return deployment.Status.UpdatedReplicas >= desiredReplicas &&
+			deployment.Status.ReadyReplicas >= desiredReplicas &&
+			deployment.Status.AvailableReplicas >= desiredReplicas
+	}, agentTestTimeout, agentTestInterval).Should(BeTrue(), "agent deployment %q should become ready", deploymentName)
 }
 
 func CreateRedfishClientPod(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {

--- a/test/virtbmc-agent/agent_test.go
+++ b/test/virtbmc-agent/agent_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -79,8 +78,8 @@ var _ = Describe("Agent e2e", Ordered, func() {
 			Expect(err).To(HaveOccurred(), "IPMI command should fail when IPMI is disabled")
 
 			By("recording the current pod UID before enabling IPMI")
-			var podBefore corev1.Pod
-			Expect(k8sClient.Get(ctx, testutil.AgentPodKey(ns), &podBefore)).To(Succeed())
+			podBefore, err := testutil.AgentPod(ctx, k8sClient, ns)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("enabling IPMI on the VirtualMachineBMC")
 			bmc := &bmcv1.VirtualMachineBMC{}
@@ -687,13 +686,13 @@ var _ = Describe("Agent e2e", Ordered, func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("recording the current agent pod UID")
-					var podBefore corev1.Pod
-					Expect(k8sClient.Get(ctx, testutil.AgentPodKey(ns), &podBefore)).To(Succeed())
+					podBefore, err := testutil.AgentPod(ctx, k8sClient, ns)
+					Expect(err).NotTo(HaveOccurred())
 
 					By("deleting the agent pod to trigger restart")
-					var podToDelete corev1.Pod
-					Expect(k8sClient.Get(ctx, testutil.AgentPodKey(ns), &podToDelete)).To(Succeed())
-					Expect(k8sClient.Delete(ctx, &podToDelete)).To(Succeed())
+					podToDelete, err := testutil.AgentPod(ctx, k8sClient, ns)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Delete(ctx, podToDelete)).To(Succeed())
 
 					By("waiting for new agent pod to be recreated and ready")
 					Eventually(testutil.PodRunningAndReadyWithNewUID(ctx, k8sClient, ns, podBefore.UID), agentTestTimeout, agentTestInterval).Should(BeTrue(), "new agent pod should become ready")

--- a/test/virtbmc-controller/controller_test.go
+++ b/test/virtbmc-controller/controller_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+	virtualmachinebmccontroller "kubevirt.io/kubevirtbmc/internal/controller/virtualmachinebmc"
 	"kubevirt.io/kubevirtbmc/test/util"
 )
 
@@ -262,16 +263,17 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 	})
 
 	Context("when the Secret is modified", func() {
-		It("should rollout restart the agent Deployment", func() {
+		It("should roll out the agent Deployment via the secret-hash annotation", func() {
 			By("verifying the agent Pod is running before the change")
 			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 
 			var deploymentBefore appsv1.Deployment
 			Expect(k8sClient.Get(ctx, util.AgentDeploymentKey(util.E2ENamespace), &deploymentBefore)).To(Succeed())
-			originalRestartedAt := ""
+			originalSecretHash := ""
 			if deploymentBefore.Spec.Template.Annotations != nil {
-				originalRestartedAt = deploymentBefore.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+				originalSecretHash = deploymentBefore.Spec.Template.Annotations[virtualmachinebmccontroller.SecretHashAnnotation]
 			}
+			Expect(originalSecretHash).NotTo(BeEmpty())
 
 			By("modifying the Secret")
 			secret := &corev1.Secret{}
@@ -279,7 +281,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			secret.Data["password"] = []byte("new-password")
 			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
 
-			By("verifying the controller reacted by updating the Deployment restart annotation")
+			By("verifying the controller reacted by updating the Deployment's secret-hash annotation")
 			Eventually(func() bool {
 				var deployment appsv1.Deployment
 				if err := k8sClient.Get(ctx, util.AgentDeploymentKey(util.E2ENamespace), &deployment); err != nil {
@@ -288,9 +290,9 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 				if deployment.Spec.Template.Annotations == nil {
 					return false
 				}
-				restartedAt := deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
-				return restartedAt != "" && restartedAt != originalRestartedAt
-			}, timeout, interval).Should(BeTrue(), "agent Deployment should get a rollout restart annotation when Secret is modified")
+				secretHash := deployment.Spec.Template.Annotations[virtualmachinebmccontroller.SecretHashAnnotation]
+				return secretHash != "" && secretHash != originalSecretHash
+			}, timeout, interval).Should(BeTrue(), "agent Deployment should get a new secret-hash annotation when Secret is modified")
 
 			By("verifying the agent Pod is running after controller reconciles")
 			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
@@ -313,13 +315,18 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			}, timeout, interval).Should(BeTrue(), "Pod should be recreated without IPMI port")
 		})
 
-		It("should recreate Pod and patch Service with IPMI ports", func() {
+		It("should update the Deployment in place, roll the Pod, and patch the Service with IPMI ports", func() {
 			By("recording the current Pod and verifying it has no IPMI port")
 			podBefore, err := util.AgentPod(ctx, k8sClient, util.E2ENamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podBefore.Spec.Containers).To(HaveLen(1))
 			Expect(podBefore.Spec.Containers[0].Ports).To(HaveLen(1))
 			Expect(podBefore.Spec.Containers[0].Ports[0].Name).To(Equal("redfish"))
+
+			By("recording the current Deployment UID")
+			var deploymentBefore appsv1.Deployment
+			Expect(k8sClient.Get(ctx, util.AgentDeploymentKey(util.E2ENamespace), &deploymentBefore)).To(Succeed())
+			deploymentBeforeUID := deploymentBefore.UID
 
 			By("recording the current Service and verifying it has no IPMI port")
 			var svcBefore corev1.Service
@@ -335,7 +342,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			bmc.Spec.IPMI = &bmcv1.IPMISpec{Enabled: &enabled}
 			Expect(k8sClient.Update(ctx, bmc)).To(Succeed())
 
-			By("waiting for the Pod to be recreated with new UID and IPMI port")
+			By("waiting for the Pod to be rolled with a new UID and IPMI port")
 			Eventually(func() bool {
 				pod, err := util.AgentPod(ctx, k8sClient, util.E2ENamespace)
 				if err != nil {
@@ -344,7 +351,12 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 				return pod.UID != podBefore.UID &&
 					len(pod.Spec.Containers) == 1 &&
 					len(pod.Spec.Containers[0].Ports) == 2
-			}, timeout, interval).Should(BeTrue(), "Pod should be recreated with IPMI port")
+			}, timeout, interval).Should(BeTrue(), "Pod should be rolled with IPMI port")
+
+			By("verifying the Deployment itself was updated in place (same UID), not deleted and recreated")
+			var deploymentAfter appsv1.Deployment
+			Expect(k8sClient.Get(ctx, util.AgentDeploymentKey(util.E2ENamespace), &deploymentAfter)).To(Succeed())
+			Expect(deploymentAfter.UID).To(Equal(deploymentBeforeUID), "Deployment should be updated via Server-Side Apply, not deleted and recreated")
 
 			By("waiting for the Service to be patched with same UID, same ClusterIP, and IPMI port")
 			Eventually(func() bool {

--- a/test/virtbmc-controller/controller_test.go
+++ b/test/virtbmc-controller/controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +27,7 @@ const (
 )
 
 var (
-	serviceAccountName = util.E2EAgentPodName
+	serviceAccountName = util.E2EAgentDeploymentName
 	roleBindingName    = util.E2EVMName + "-virtbmc-rolebinding"
 )
 
@@ -134,17 +135,17 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			}, timeout, interval).Should(BeTrue(), "RoleBinding should be created")
 		})
 
-		It("should create a ready agent Pod", func() {
-			By("verifying the agent Pod exists")
-			Eventually(util.PodExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should be created")
-			By("verifying the agent Pod is Running")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+		It("should create an agent Deployment and mark it ready", func() {
+			By("verifying the agent Deployment exists")
+			Eventually(util.DeploymentExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should be created")
+			By("verifying the agent Deployment becomes ready")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 		})
 
 		It("should create an agent Service", func() {
 			Eventually(func() bool {
 				svc := &corev1.Service{}
-				return k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), svc) == nil
+				return k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), svc) == nil
 			}, timeout, interval).Should(BeTrue(), "agent Service should be created")
 		})
 
@@ -172,7 +173,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 
 	Context("when the VirtualMachine is deleted", func() {
 
-		It("should delete the agent Pod and set VirtualMachineAvailable=False", func() {
+		It("should delete the agent Deployment and set VirtualMachineAvailable=False", func() {
 			By("deleting the VirtualMachine")
 
 			vm := &kubevirtv1.VirtualMachine{}
@@ -187,9 +188,9 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			Eventually(util.VMNotFound(ctx, k8sClient, util.E2EVMName, util.E2ENamespace), vmDeletionTimeout, interval).Should(BeTrue(),
 				"VirtualMachine should be fully deleted")
 
-			By("verifying the agent Pod is removed")
-			Eventually(util.PodNotFound(ctx, k8sClient, util.E2ENamespace), vmDeletionTimeout, interval).Should(BeTrue(),
-				"agent Pod should be deleted when VM is gone")
+			By("verifying the agent Deployment is removed")
+			Eventually(util.DeploymentNotFound(ctx, k8sClient, util.E2ENamespace), vmDeletionTimeout, interval).Should(BeTrue(),
+				"agent Deployment should be deleted when VM is gone")
 
 			By("verifying VirtualMachineAvailable=False with reason VirtualMachineNotFound")
 			Eventually(
@@ -219,22 +220,23 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 				timeout, interval,
 			).Should(BeTrue())
 
-			By("verifying the agent Pod is re-created and running")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+			By("verifying the agent Deployment is re-created and becomes ready")
+			Eventually(util.DeploymentExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should be re-created")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 
 		})
 	})
 
 	Context("when the Secret is deleted", func() {
-		It("should delete the agent Pod and set SecretAvailable=False", func() {
+		It("should delete the agent Deployment and set SecretAvailable=False", func() {
 			By("deleting the Secret")
 			secret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: util.E2ESecretName, Namespace: util.E2ENamespace}, secret)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
 
-			By("verifying the agent Pod is removed")
-			Eventually(util.PodNotFound(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(),
-				"agent Pod should be deleted when Secret is gone")
+			By("verifying the agent Deployment is removed")
+			Eventually(util.DeploymentNotFound(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(),
+				"agent Deployment should be deleted when Secret is gone")
 
 			By("verifying SecretAvailable=False with reason SecretNotFound")
 			Eventually(
@@ -253,19 +255,23 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 				timeout, interval,
 			).Should(BeTrue())
 
-			By("verifying the agent Pod is re-created and running")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+			By("verifying the agent Deployment is re-created and becomes ready")
+			Eventually(util.DeploymentExists(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should be re-created")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 		})
 	})
 
 	Context("when the Secret is modified", func() {
-		It("should delete the agent Pod and let the controller recreate it", func() {
+		It("should rollout restart the agent Deployment", func() {
 			By("verifying the agent Pod is running before the change")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 
-			var podBefore corev1.Pod
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &podBefore)).To(Succeed())
-			originalUID := podBefore.UID
+			var deploymentBefore appsv1.Deployment
+			Expect(k8sClient.Get(ctx, util.AgentDeploymentKey(util.E2ENamespace), &deploymentBefore)).To(Succeed())
+			originalRestartedAt := ""
+			if deploymentBefore.Spec.Template.Annotations != nil {
+				originalRestartedAt = deploymentBefore.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+			}
 
 			By("modifying the Secret")
 			secret := &corev1.Secret{}
@@ -273,17 +279,21 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			secret.Data["password"] = []byte("new-password")
 			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
 
-			By("verifying the controller reacted: pod is removed and/or recreated with new UID")
+			By("verifying the controller reacted by updating the Deployment restart annotation")
 			Eventually(func() bool {
-				var pod corev1.Pod
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &pod); err != nil {
-					return errors.IsNotFound(err)
+				var deployment appsv1.Deployment
+				if err := k8sClient.Get(ctx, util.AgentDeploymentKey(util.E2ENamespace), &deployment); err != nil {
+					return false
 				}
-				return pod.UID != originalUID
-			}, timeout, interval).Should(BeTrue(), "agent Pod should be deleted or recreated when Secret is modified")
+				if deployment.Spec.Template.Annotations == nil {
+					return false
+				}
+				restartedAt := deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+				return restartedAt != "" && restartedAt != originalRestartedAt
+			}, timeout, interval).Should(BeTrue(), "agent Deployment should get a rollout restart annotation when Secret is modified")
 
 			By("verifying the agent Pod is running after controller reconciles")
-			Eventually(util.PodRunningAndReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Pod should become Running and Ready")
+			Eventually(util.DeploymentReady(ctx, k8sClient, util.E2ENamespace), timeout, interval).Should(BeTrue(), "agent Deployment should become ready")
 		})
 	})
 
@@ -295,8 +305,8 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			bmcReset.Spec.IPMI = nil
 			Expect(k8sClient.Update(ctx, bmcReset)).To(Succeed())
 			Eventually(func() bool {
-				var pod corev1.Pod
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &pod); err != nil {
+				pod, err := util.AgentPod(ctx, k8sClient, util.E2ENamespace)
+				if err != nil {
 					return false
 				}
 				return len(pod.Spec.Containers) == 1 && len(pod.Spec.Containers[0].Ports) == 1
@@ -305,15 +315,15 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 
 		It("should recreate Pod and patch Service with IPMI ports", func() {
 			By("recording the current Pod and verifying it has no IPMI port")
-			var podBefore corev1.Pod
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &podBefore)).To(Succeed())
+			podBefore, err := util.AgentPod(ctx, k8sClient, util.E2ENamespace)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(podBefore.Spec.Containers).To(HaveLen(1))
 			Expect(podBefore.Spec.Containers[0].Ports).To(HaveLen(1))
 			Expect(podBefore.Spec.Containers[0].Ports[0].Name).To(Equal("redfish"))
 
 			By("recording the current Service and verifying it has no IPMI port")
 			var svcBefore corev1.Service
-			Expect(k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svcBefore)).To(Succeed())
+			Expect(k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svcBefore)).To(Succeed())
 			Expect(svcBefore.Spec.Ports).To(HaveLen(1))
 			Expect(svcBefore.Spec.Ports[0].Name).To(Equal("redfish"))
 			svcBeforeClusterIP := svcBefore.Spec.ClusterIP
@@ -327,8 +337,8 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 
 			By("waiting for the Pod to be recreated with new UID and IPMI port")
 			Eventually(func() bool {
-				var pod corev1.Pod
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &pod); err != nil {
+				pod, err := util.AgentPod(ctx, k8sClient, util.E2ENamespace)
+				if err != nil {
 					return false
 				}
 				return pod.UID != podBefore.UID &&
@@ -339,7 +349,7 @@ var _ = Describe("KubeVirtBMC controller manager", Ordered, func() {
 			By("waiting for the Service to be patched with same UID, same ClusterIP, and IPMI port")
 			Eventually(func() bool {
 				var svc corev1.Service
-				if err := k8sClient.Get(ctx, util.AgentPodKey(util.E2ENamespace), &svc); err != nil {
+				if err := k8sClient.Get(ctx, util.AgentServiceKey(util.E2ENamespace), &svc); err != nil {
 					return false
 				}
 				return svc.UID == svcBefore.UID &&


### PR DESCRIPTION
Tracking issue: #162, #262

- Changed the pod with deployment
- Refractor the controller test 
- Refractor the E2E. 
- Move the labels to api level so that both controller and agent can consume. 

> [!NOTE]
> As a part this PR the default value of the bmc deployment replica is set to 1. User are not allow to set the replicas to 2 . We need to introduce the new field in the CRD. I will create the sub task for it in issue 136

